### PR TITLE
Submit button copy & state

### DIFF
--- a/recurly.js
+++ b/recurly.js
@@ -1838,7 +1838,7 @@ R.buildSubscriptionForm = function(options) {
             }
           }
         , complete: function() {
-            if(options.successURL) return;
+            if(options.successURL || options.afterSubscribe) return;
             $form.removeClass('submitting');
             $form.find('button.submit').removeAttr('disabled').text(options.submitButtonText || 'Subscribe');
           }


### PR DESCRIPTION
If successURL is defined, the submit button should not be re-enabled because we're redirecting on successful submit anyway. This is so as not to confuse the user and allow them to re-submit as the page is redirecting.

Re-enable the button on error.

Also added option to override the text in the button.
