### PR TITLE
Adds configurable quantity to subscription form

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -148,6 +148,7 @@ var preFillMap = {
   }
 , subscription: {
     couponCode:     '.subscription > .coupon > .coupon_code > input'
+    , quantity: '.subscription > .plan > .quantity > input'
   }
 };
 
@@ -1058,6 +1059,7 @@ R.buildSubscriptionForm = function(options) {
       }
     });
 
+    updateTotals();
   }
 
 };


### PR DESCRIPTION
The buildSubscriptionForm options should accept quantity along with couponCode in the subscription preFillMap to allow pre-population of plan quantities.
