### PR TITLE
Syntax Error in R.flattenErrors

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -154,7 +154,7 @@ R.flattenErrors = function(obj, attr) {
 
   var baseErrorKeys = ['base','account_id'];
 
-  var attr = attr || '';
+  attr = attr || '';
 
   if(  typeof obj == 'string'
     || typeof obj == 'number'


### PR DESCRIPTION
`attr` is already in the local scope because it's an argument, so this
throws different errors in different browsers. Chrome thinks it's a
syntax error and dies.
