### PR TITLE
Adds travis artifact uploader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: node_js
-script: make test-sauce
+script: 'if [ -n "$ARTIFACT" ]; then make test; else make test-sauce; fi'
 node_js:
   - '0.10'
+before_script:
+  - 'if [ -n "$ARTIFACT" ]; then gem install travis-artifacts; fi'
+after_success:
+  - 'if [ -n "$ARTIFACT" ]; then travis-artifacts upload --path recurly.min.js --target-path artifacts/$TRAVIS_COMMIT; fi'
 env:
   global:
+    - secure: 1Fve9UwwgFSoX0Qemh2CkAN9Nyo/bkT5nrHx0MVbc4jRziw8IWdluOPNnzg+Zpx7NXu1BPIUsOvMCjsfJcpJhiuqNPMZZHFfT7vOXW3Htj3UbxrQKpNpyFPQSfCoO4Xz7a3VNusLLqx1RTnFr7plV9F7vrUf8IsL1yYXCyWa6W0=
+    - secure: QLUFB2xoxYmlhIgsuyZzcOY9qKeB6Ct/WOmXXfOkX5bOMyWvjnTtWK5x2qRn813qFBX3/xED9CcQhmJBEgzCBCXodFkgAXGON1mIqJvN5ubBs2fsejF4+/dnVnSiZ3zy0bQKEofTJJZisESaQ4N7a/CmIXgBJtFedDGvxB4ibSs=
+    - secure: NUIojJW7KxzxTvWDKAwPb9ph8x1G/tEE3UL50HRsCOjEbtKYWJT887T3ZAzTXMslZictEeBUD9d4/BymUUy6dOfvohhMCZbXy5ebFHDnCiayPnoxtYXDjaoSZoMTM/wkcFBCNXtauzrkAD1q+aSauONLcSSu0IM5V4LMsCRAz3E=
+    - secure: hP6DZjohCePpsqNoD0gzaOwWij4GIh3znS0SY87HCVzsymkrL23t0R4vKxmqOp+qQ3erSwDFT0B6NImWMnIhroIBNzWXrZ8AsT8PACv/fCOzxpR0UuiBOZMPXnkCzygoSmLYF/Xg72kyDSAABdWNwPxLEc0tBIH/e0iN8G2R2sg=
     - secure: jQt9v3zZAKmq774J4TOm8a6Zgxea83faf++RRM3azsgLSz5vLfZK6IH4UiC9SmiMZVTYa87mTA71+IO8Mg0lUDJoF8F3EHB+U957el4fDdGak5OULz6FCh0tME1lsstHi+GJ3GtdJGA1DsC6bUR+DsPB5anZZ+wl3QGdUCJToeY=
     - secure: Bv5h9pXMa5O0EdOuN2Dt1n9/+T1dMHimnn6XQb0ozjfwzjfhcPR6eKHkOxDVJ0c1rzne48ql0FK0P42QaCdZpEmy8wUyUTmI1gTMhjILcFbQFk+r9GOwGJsPttLNRS2J9+8u5tEDZjf5LiCnPBjy6vIinK7nlas93xTLTQwNEmI=
   matrix:
@@ -13,3 +21,4 @@ env:
     - BROWSER: ie8..11
     - BROWSER: ipad5..7
     - BROWSER: iphone5..7
+    - ARTIFACT: 1


### PR DESCRIPTION
This will get travis to send `recurly.min.js` to an s3 bucket for safe-keeping, so we'll have compiled targets for all commits that Travis runs.

cc @gjohnson 
