### PR TITLE
Corrects coupon rounding behavior in Pricing.calculations

### DIFF
--- a/lib/mixins/pricing/calculations.js
+++ b/lib/mixins/pricing/calculations.js
@@ -156,8 +156,8 @@ Calculations.prototype.discount = function () {
 
   if (coupon) {
     if (coupon.discount.rate) {
-      this.price.now.discount = this.price.now.subtotal * coupon.discount.rate;
-      this.price.next.discount = this.price.next.subtotal * coupon.discount.rate;
+      this.price.now.discount = Math.round(this.price.now.subtotal * coupon.discount.rate * 100) / 100;
+      this.price.next.discount = Math.round(this.price.next.subtotal * coupon.discount.rate * 100) / 100;
     } else {
       this.price.now.discount = coupon.discount.amount[this.items.currency];
       this.price.next.discount = coupon.discount.amount[this.items.currency];


### PR DESCRIPTION
##### previously

```
subtotal * rate = discount
19.95 * 0.5 = 9.975

subtotal - discount = subtotal after discount ~> rounded
19.95 - 9.975 = 9.975 ~> 9.98
```

**=** 9.98
##### now

```
subtotal * rate = discount ~> rounded discount
19.95 * 0.5 = 9.975 ~> 9.98

subtotal - rounded discount = subtotal after discount
19.95 - 9.98 = 9.97
```

**=** 9.97

cc @cbarton 
