### PR TITLE
Adds 'phone' and 'vat_number' to list of tokenizable fields

### DIFF
--- a/lib/mixins/token.js
+++ b/lib/mixins/token.js
@@ -32,6 +32,8 @@ var fields = [
   , 'city'
   , 'state'
   , 'postal_code'
+  , 'phone'
+  , 'vat_number'
   , 'token'
 ];
 


### PR DESCRIPTION
Fixes #119 

This will add the rest of the [billing info attributes](https://docs.recurly.com/api/billing-info#update-billing-info-credit-card) that are not card information and billing address: `phone` and `vat_number`.

cc @gjohnson 
