### PR TITLE
Slightly refactors Pricing.attach to correctly chain dependent pricing functions

### DIFF
--- a/lib/mixins/pricing/attach.js
+++ b/lib/mixins/pricing/attach.js
@@ -5,16 +5,12 @@
 var each = require('each');
 var events = require('event');
 var find = require('find');
-var index = require('indexof');
+var type = require('type');
 var dom = require('../../util/dom');
 var debug = require('debug')('recurly:pricing:attach');
 
 /**
  * bind a dom element to pricing values
- *
- * TODO
- *   - move this into a plugin?
- *   - better name?
  *
  * @param {HTMLElement} el
  */
@@ -48,18 +44,34 @@ exports.attach = function (el) {
   function change (event) {
     debug('change');
 
-    var target = event && event.target && dom.data(event.target, 'recurly')
-              || window.event && window.event.srcElement;
-
-    var all = !target;
+    var targetName = event && event.target && dom.data(event.target, 'recurly');
+        targetName = targetName || window.event && window.event.srcElement;
 
     var pricing = self.plan(dom.value(elems.plan), { quantity: dom.value(elems.plan_quantity) });
     
-    if (all || target === 'currency') {
+    if (target('currency')) {
       pricing = pricing.currency(dom.value(elems.currency));
     }
 
-    if ((all || target === 'addon') && elems.addon) {
+    if (target('addon') && elems.addon) {
+      pricing = pricing.then(addons);
+    }
+
+    if (target('coupon') && elems.coupon) {
+      pricing = pricing.coupon(dom.value(elems.coupon)).then(null, ignoreBadCoupons);
+    }
+
+    if (target('country') || target('postal_code') || target('vat_number')) {
+      pricing = pricing.address({
+        country: dom.value(elems.country),
+        postal_code: dom.value(elems.postal_code),
+        vat_number: dom.value(elems.vat_number)
+      });
+    }
+
+    pricing.done();
+
+    function addons () {
       each(elems.addon, function (node) {
         var plan = self.items.plan;
         var addonCode = dom.data(node, 'recurlyAddon');
@@ -69,22 +81,11 @@ exports.attach = function (el) {
       });
     }
 
-    if ((all || target === 'coupon') && elems.coupon) {
-      pricing = pricing.coupon(dom.value(elems.coupon))['catch'](function (err) {
-        if (err.code === 'not-found') return;
-        else throw err;
-      });
+    function target (name) {
+      if (!targetName) return true;
+      if (targetName === name) return true;
+      return false
     }
-
-    if (all || ~index(['country', 'postal_code', 'vat_number'], target)) {
-      pricing = pricing.address({
-        country: dom.value(elems.country),
-        postal_code: dom.value(elems.postal_code),
-        vat_number: dom.value(elems.vat_number)
-      });
-    }
-
-    pricing.done();
   };
 
   function update (price) {
@@ -111,6 +112,11 @@ exports.attach = function (el) {
     }, this);
   }
 };
+
+function ignoreBadCoupons (err) {
+  if (err.code === 'not-found') return;
+  else throw err;
+}
 
 /**
  * Backward-compatibility

--- a/lib/mixins/pricing/index.js
+++ b/lib/mixins/pricing/index.js
@@ -211,7 +211,7 @@ Pricing.prototype.addon = function (addonCode, meta, done) {
     var quantity = addonQuantity(meta, planAddon);
     var addon = findAddon(self.items.addons, addonCode);
 
-    if (isNaN(quantity) || quantity === 0) {
+    if (quantity === 0) {
       self.remove({ addon: addonCode });
     }
 

--- a/lib/mixins/pricing/promise.js
+++ b/lib/mixins/pricing/promise.js
@@ -73,7 +73,7 @@ PricingPromise.prototype.constructor = PricingPromise;
  */
 
 PricingPromise.prototype.done = function () {
-  Promise.prototype.done.apply(this.reprice(), arguments);
+  Promise.prototype.done.apply(this.then(this.reprice), arguments);
   return this.pricing;
 };
 


### PR DESCRIPTION
This is largely to address a question from [StackOverflow](http://stackoverflow.com/questions/24078698/recurly-js-v3-and-addons).

`Pricing.prototype.attach` would run through the binding elements, but in the case of addons would try to check for plan properties before the plan was necessarily available on the pricing instance. This ensures it gets added to the `PricingPromise` chain correctly.

Within the `PricingPromise`, reprice was being called ahead of time on the done call. This ensures it is run at the conclusion of the chain.
