### PR TITLE
Adds event after State address field swap is complete.

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -363,6 +363,8 @@ function initBillingInfoForm($form, options) {
       // Restore original manual state input field
       $state.empty().append($manualStateInput).removeClass('select_mode');
     }
+    // Triggers event should anything need to act on this field after the swap.
+    $state.trigger('recurly_state_swap');
   }
 
   $stateInput.bind('change keyup', function() {


### PR DESCRIPTION
We are using the [Chosen jQuery plugin](http://harvesthq.github.io/chosen/) for select lists on all forms, including Recurly.js forms. We ran into an issue when the State address field on the Billing form is swapped between a text field and a select list depending on the value of the Country field. We needed to reapply Chosen each time the swap for a select list is made. We found that the easiest way to do that was to trigger an event after the swap is complete.
