### PR TITLE
Corrects addon promise chain order

### DIFF
--- a/lib/recurly/pricing/attach.js
+++ b/lib/recurly/pricing/attach.js
@@ -54,7 +54,7 @@ exports.attach = function (el) {
     }
 
     if (target('addon') && elems.addon) {
-      pricing = pricing.then(addons);
+      addons();
     }
 
     if (target('coupon') && elems.coupon) {


### PR DESCRIPTION
The correct thing to do here is to iterate over addons and call their pricing methods in order. We had been simply attaching the iterator method onto the promise chain, allowing a race condition to issue reprices before all addons were attached to the pricing module.

/cc @gjohnson 
