### PR TITLE
Append tax information to pricing object

### DIFF
--- a/lib/recurly/pricing/calculations.js
+++ b/lib/recurly/pricing/calculations.js
@@ -103,10 +103,14 @@ Calculations.prototype.tax = function (done) {
       if (err) {
         self.pricing.emit('error', err);
       } else {
+        self.price.taxes = [];
         each(taxes, function (tax) {
           if (tax.type === 'usst' && self.items.plan.tax_exempt) return;
           self.price.now.tax += parseFloat((self.price.now.subtotal * tax.rate).toFixed(6));
           self.price.next.tax += parseFloat((self.price.next.subtotal * tax.rate).toFixed(6));
+          // If we have taxes, we may want to display the rate...
+          // push the taxes so we know what they are...
+          self.price.taxes.push(tax)
         });
 
         // tax estimation prefers partial cents to always round up

--- a/test/index.js
+++ b/test/index.js
@@ -9,3 +9,4 @@ require('./unit/plan.test.js');
 require('./unit/tax.test.js');
 require('./unit/token.test.js');
 require('./unit/validate.test.js');
+require('./unit/recurly/priceing.test.js');

--- a/test/server/fixtures/tax/index.js
+++ b/test/server/fixtures/tax/index.js
@@ -5,12 +5,24 @@
 
 var USST_POSTAL_CODE = '94110';
 
+/**
+ * postal code to match for US sales tax
+ * with region data returned
+ */
+
+var USST_POSTAL_CODE_WITH_REGION = '94129';
 
 /**
  * country code to match for VAT
  */
 
 var VAT_COUNTRY = 'DE';
+
+/**
+ * country code to match for VAT 2015
+ */
+
+var VAT_2015_COUNTRY = 'GB';
 
 /**
  * US sales tax response
@@ -26,7 +38,9 @@ var VAT_COUNTRY = 'DE';
 
 module.exports = function tax (req, res) {
   if (req.query.country === 'US' && req.query.postal_code === USST_POSTAL_CODE) return usst;
+  if (req.query.country === 'US' && req.query.postal_code === USST_POSTAL_CODE_WITH_REGION) return usst_with_region;
   if (req.query.country === VAT_COUNTRY) return vat;
+  if (req.query.country === VAT_2015_COUNTRY) return vat_2015;
   return none;
 };
 
@@ -35,9 +49,21 @@ var usst = [{
   rate: '0.0875'
 }];
 
+var usst_with_region = [{
+  type: 'us',
+  rate: '0.0875',
+  region: 'CA'
+}];
+
 var vat = [{
   type: 'vat',
   rate: '0.015'
+}];
+
+var vat_2015 = [{
+  type: 'vat',
+  rate: '0.2',
+  region: 'GB'
 }];
 
 var none = [];

--- a/test/unit/recurly/priceing.test.js
+++ b/test/unit/recurly/priceing.test.js
@@ -1,0 +1,104 @@
+
+var assert = require('assert');
+
+describe('Recurly.Pricing', function () {
+  var Recurly = window.recurly.Recurly;
+  var recurly;
+
+  beforeEach(function () {
+    recurly = new Recurly();
+    recurly.configure({
+      publicKey: 'test',
+      api: '//' + window.location.host
+    });
+  });
+
+  it('should not append tax elements if there is no tax', function (done) {
+    recurly
+      .Pricing()
+      .plan('basic', { quantity: 1 })
+      .address({
+        country: 'US',
+        postal_code: 'NoTax'
+      })
+      .done(function(price) {
+          assert.equal(price.taxes.length, 0)
+          assert.equal(price.now.tax, '0.00')
+          assert.equal(price.next.tax, '0.00')
+          done()
+      });
+  });
+  
+  it('should append US tax elements in the US', function (done) {
+    recurly
+      .Pricing()
+      .plan('basic', { quantity: 1 })
+      .address({
+        country: 'US',
+        postal_code: '94110' // tax literal for test
+      })
+      .done(function(price) {
+          assert.equal(price.taxes.length, 1)
+          assert.equal(price.taxes[0].type, 'us')
+          assert.equal(price.taxes[0].rate, '0.0875')
+          assert.equal(price.now.tax, '0.18')
+          assert.equal(price.next.tax, '1.75')
+          done()
+      });
+  });
+  
+  it('should append VAT tax elements if in the EU', function (done) {
+    recurly
+      .Pricing()
+      .plan('basic', { quantity: 1 })
+      .address({
+        country: 'DE'
+      })
+      .done(function(price) {
+          assert.equal(price.taxes.length, 1)
+          assert.equal(price.taxes[0].type, 'vat')
+          assert.equal(price.taxes[0].rate, '0.015')
+          assert.equal(price.now.tax, '0.03')
+          assert.equal(price.next.tax, '0.30')
+          done()
+      });
+  });
+  
+  it('should append US state tax, similar to 2015 VAT regulations', function (done) {
+    recurly
+      .Pricing()
+      .plan('basic', { quantity: 1 })
+      .address({
+        country: 'US',
+        postal_code: '94129' // tax literal for test
+      })
+      .done(function(price) {
+          assert.equal(price.taxes.length, 1)
+          assert.equal(price.taxes[0].type, 'us')
+          assert.equal(price.taxes[0].rate, '0.0875')
+          assert.equal(price.taxes[0].region, 'CA')
+          assert.equal(price.now.tax, '0.18')
+          assert.equal(price.next.tax, '1.75')
+          done()
+      });
+  });
+  
+  it('should append VAT tax elements if in the EU and region for 2015 type rules', function (done) {
+    recurly
+      .Pricing()
+      .plan('basic', { quantity: 1 })
+      .address({
+        country: 'GB'
+      })
+      .done(function(price) {
+          assert.equal(price.taxes.length, 1)
+          assert.equal(price.taxes[0].type, 'vat')
+          assert.equal(price.taxes[0].region, 'GB')
+          assert.equal(price.taxes[0].rate, '0.2')
+          assert.equal(price.now.tax, '0.40')
+          assert.equal(price.next.tax, '4.00')
+          done()
+      });
+  });
+  
+});


### PR DESCRIPTION
Append a bool `hasTax` to the Pricing object to help with templates and such.

Append the tax information to a `taxes` array on the Pricing object.

Add some tests.

(Also, you should note that you have tests at https://github.com/recurly/recurly-js/blob/master/test/unit/recurly/coupon.test.js that are not listed https://github.com/recurly/recurly-js/blob/65983710cde1354dc6502864487b32ae920ea0bf/test/index.js so it is never run... this may be on purpose...)  
