### PR TITLE
Fixes issue with pricing coupon and plan mismatches

### DIFF
--- a/lib/recurly/pricing/attach.js
+++ b/lib/recurly/pricing/attach.js
@@ -24,7 +24,7 @@ exports.attach = function (el) {
 
   if (this.attach.detatch) this.attach.detatch();
 
-  self.on('change', update);
+  this.on('change', update);
 
   each(el.querySelectorAll('[data-recurly]'), function (elem) {
     // 'zip' -> 'postal_code'
@@ -53,11 +53,11 @@ exports.attach = function (el) {
       pricing = pricing.currency(dom.value(elems.currency));
     }
 
-    if (target('addon') && elems.addon) {
+    if (elems.addon && target('addon')) {
       addons();
     }
 
-    if (target('coupon') && elems.coupon) {
+    if (elems.coupon && (target('coupon') || target('plan'))) {
       pricing = pricing.coupon(dom.value(elems.coupon)).then(null, ignoreBadCoupons);
     }
 

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -170,9 +170,18 @@ Pricing.prototype.plan = function (planCode, meta, done) {
         self.currency(keys(plan.price)[0]);
       }
 
-      debug('set.plan');
-      self.emit('set.plan', plan);
-      resolve(plan);
+      // If we have a coupon, it must be reapplied
+      if (self.items.coupon) {
+        self.coupon(self.items.coupon.code).then(finish, finish);
+      } else {
+        finish();
+      }
+
+      function finish () {
+        debug('set.plan');
+        self.emit('set.plan', plan);
+        resolve(plan);
+      }
     });
   }, this).nodeify(done);
 };
@@ -203,8 +212,8 @@ Pricing.prototype.addon = function (addonCode, meta, done) {
     var planAddon = findAddon(self.items.plan.addons, addonCode);
     if (!planAddon) {
       return reject(errors('invalid-addon', {
-          planCode: self.items.plan.code
-        , addonCode: addonCode
+        planCode: self.items.plan.code,
+        addonCode: addonCode
       }));
     }
 
@@ -243,14 +252,18 @@ Pricing.prototype.coupon = function (couponCode, done) {
 
   return new PricingPromise(function (resolve, reject) {
     if (!self.items.plan) return reject(errors('missing-plan'));
-    if (coupon) {
-      if (coupon.code === couponCode) return resolve(coupon);
-      else self.remove({ coupon: coupon.code });
+    if (coupon) self.remove({ coupon: coupon.code });
+
+    // TODO: Should this emit an 'unset' event?
+    // Need to consider other objects as well
+    if (!couponCode) {
+      debug('unset.coupon');
+      delete self.items.coupon;
+      return resolve();
     }
-    if (!couponCode) return resolve();
 
     self.recurly.coupon({ plan: self.items.plan.code, coupon: couponCode }, function (err, coupon) {
-      if (err && err.code !== 'not_found') return reject(err);
+      if (err && err.code !== 'not-found') return reject(err);
 
       self.items.coupon = coupon;
 


### PR DESCRIPTION
- Calls to pricing.coupon will no longer abort if the coupon code hasn't changed. This accomodates plan changes that may nullify a coupon that may wok on other plans
- Corrects not-found error code check in pricing.coupon
- pricing.plan calls will now make pricing.coupon calls if a coupon is set on the instance
- Fixes #175