### PR TITLE
Locks mocha-phantomjs to 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "3.x",
     "body-parser": "1.9.2",
     "jade": "1.x",
-    "mocha-phantomjs": "3.x",
+    "mocha-phantomjs": "3.5.2",
     "gravy": "0.x",
     "debug": "0.x"
   }


### PR DESCRIPTION
- Fixes build
- Due to mocha-phantomjs incompatibility with our browser-based mocha
- Follow-up: update browser mocha