### PR TITLE
Fixes validate.cardNumber throwing on falsey values

### DIFF
--- a/lib/util/parse-card.js
+++ b/lib/util/parse-card.js
@@ -7,5 +7,5 @@
  */
 
 module.exports = function parseCard (number) {
-  return number && number.toString().replace(/[-\s]/g, '');
+  return (number || '').toString().replace(/[-\s]/g, '');
 };

--- a/test/unit/validate.test.js
+++ b/test/unit/validate.test.js
@@ -16,6 +16,14 @@ describe('Recurly.validate', function () {
 
     it('should return false for invalid card numbers', function() {
       assert(false === recurly.validate.cardNumber('4111-1111-1111-1112'));
+      assert(false === recurly.validate.cardNumber('1234'));
+      assert(false === recurly.validate.cardNumber(1234));
+      assert(false === recurly.validate.cardNumber('0'));
+      assert(false === recurly.validate.cardNumber(0));
+      assert(false === recurly.validate.cardNumber('abcxyz'));
+      assert(false === recurly.validate.cardNumber(''));
+      assert(false === recurly.validate.cardNumber());
+      assert(false === recurly.validate.cardNumber(null));
     });
   });
 


### PR DESCRIPTION
- instead of parseCard returning false, it returns an empty string that cardNumber can parse
- Fixes #161

/cc @bhelx 