### PR TITLE
Allows cardType to run detections on partial numbers

### DIFF
--- a/lib/recurly/validate.js
+++ b/lib/recurly/validate.js
@@ -83,13 +83,14 @@ module.exports = {
    * TODO(chrissrogers): Maybe undefined instread of "unknown"?
    *
    * @param {Number|String} number The card number
+   * @param {Boolean} partial detect card type on a partial (incomplete) number
    * @return {String} card type
    */
 
-  cardType: function (number) {
+  cardType: function (number, partial) {
     var str = parseCard(number);
     var card = find(types, function (card) {
-      return card.pattern.test(str) && ~index(card.lengths, str.length);
+      return card.pattern.test(str) && (partial || ~index(card.lengths, str.length));
     });
     return card && card.type || 'unknown';
   },

--- a/test/unit/validate.test.js
+++ b/test/unit/validate.test.js
@@ -30,17 +30,27 @@ describe('Recurly.validate', function () {
   describe('cardType', function() {
     it('should parse visa', function() {
       var type = recurly.validate.cardType('4111-1111-1111-1111');
-      assert('visa' === type);
+      assert(type === 'visa');
     });
 
     it('should parse american_express', function() {
       var type = recurly.validate.cardType('372546612345678');
-      assert('american_express' === type);
+      assert(type === 'american_express');
     });
 
     it('should parse unknown', function() {
       var type = recurly.validate.cardType('867-5309-jenny');
-      assert('unknown' === type);
+      assert(type === 'unknown');
+    });
+
+    it('should not parse partial numbers', function () {
+      var type = recurly.validate.cardType('3725');
+      assert(type === 'unknown');
+    });
+
+    it('should parse partial numbers if instructed', function () {
+      var type = recurly.validate.cardType('3725', true);
+      assert(type === 'american_express');
     });
   });
 


### PR DESCRIPTION
##### Summary
- It is common to want to detect a card's type before the entire card is input.
- Adds a second boolean parameter to the method.
- Passing true to the `partial` parameter instructs the method to ignore the card length detections and rely solely on pattern detection.
