### PR TITLE
Fixes issue where Pricing detachment fails on multiple instances

### DIFF
--- a/lib/recurly/pricing/attach.js
+++ b/lib/recurly/pricing/attach.js
@@ -22,7 +22,7 @@ exports.attach = function (el) {
 
   if (!el) throw new Error('invalid dom element');
 
-  if (this.attach.detatch) this.attach.detatch();
+  if (this.detatch) this.detatch();
 
   this.on('change', update);
 
@@ -37,7 +37,7 @@ exports.attach = function (el) {
     events.bind(elem, 'propertychange', change);
   });
 
-  this.attach.detatch = detatch;
+  this.detatch = detatch;
 
   change();
 
@@ -99,6 +99,7 @@ exports.attach = function (el) {
     dom.value(elems.currency_symbol, price.currency.symbol);
 
     dom.value(elems.plan_base, price.base.plan.unit);
+    dom.value(elems.plan_interval, price.base.plan.interval)
 
     each(['plan', 'addons', 'discount', 'setup_fee', 'subtotal', 'tax', 'total'], function (value) {
       dom.value(elems[value + '_now'], price.now[value]);


### PR DESCRIPTION
##### Summary

- This places the detachment method on the true instance, instead of storing on the attach method prototype
- When multiple pricing instances from the same `Pricing` prototype definition are attached to separate forms, the pricing `attach` method would look for detach on the `attach` prototype. This should instead reside strictly on the instance.