### PR TITLE
Fix issue where Pricing dont fail when the coupon is invalid

### DIFF
--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -263,7 +263,7 @@ Pricing.prototype.coupon = function (couponCode, done) {
     }
 
     self.recurly.coupon({ plan: self.items.plan.code, coupon: couponCode }, function (err, coupon) {
-      if (err && err.code !== 'not-found') return reject(err);
+      if (err && err.code === 'not-found') return reject(err);
 
       self.items.coupon = coupon;
 


### PR DESCRIPTION
The origin of this issue is here: https://github.com/recurly/recurly-js/issues/193
The fixed line was touched in the between 3.0.10 and 3.0.11 but not complete right.

