### PR TITLE
Add optional field validation

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -103,6 +103,8 @@ Recurly.prototype.configure = function (options) {
     this.config.currency = options.currency;
   }
 
+  this.config.required = options.required || [];
+
   this.configured = true;
 };
 

--- a/lib/recurly/token.js
+++ b/lib/recurly/token.js
@@ -145,5 +145,15 @@ function validate (input) {
     errors.push('last_name');
   }
 
+  if (input.cvv && !this.validate.cvv(input.cvv)) {
+    errors.push('cvv');
+  }
+
+  each(this.config.required, function(field) {
+    if (!input[field] && ~index(fields, field)) {
+      errors.push(field);
+    }
+  });
+
   return errors;
 }

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -17,6 +17,7 @@ describe('Recurly.configure', function () {
       , { invalid: 'parameter' }
       , { currency: 'USD' }
       , { currency: 'AUD', api: 'https://localhost' }
+      , { currency: 'USD', api: 'https://localhost', required: ['postal_code'] }
     ];
 
     it('throws', function () {
@@ -42,6 +43,8 @@ describe('Recurly.configure', function () {
       , { publicKey: 'foo', currency: 'USD' }
       , { publicKey: 'foo', currency: 'AUD', api: 'https://localhost' }
       , { publicKey: 'foo', currency: 'AUD', api: 'https://localhost', cors: true }
+      , { publicKey: 'foo', currency: 'USD', api: 'https://localhost', required: ['country'] }
+      , { publicKey: 'foo', currency: 'USD', api: 'https://localhost', required: ['postal_code', 'country'] }
     ];
 
     it('sets Recurly.config to the options given', function () {


### PR DESCRIPTION
Hello,

At work, I needed additional field validations on client side so I created this PR :)
This PR gives us(merchants) a control about which additional required fields to be validated on browser.

**Changes:**
  Change token.validate() to validate 'cvv' (only when cvv exists) and merchant pre-defined required fields as well.

**How it works:**
  Merchant setups additional required fields with recurly.configure().
```javascript
recurly.configure({
  'publicKey': 'abcd1234-key',
  'extraRequiredFields': ['cvv', 'postal_code', 'country']
});
```
  When user submits form, token.validate() now checks if those required fields exist or not, too, through token().
  (Also, it checks 'cvv' only when cvv has a value.)


**Why this is helpful?**
 We use recurly.js at work and we wanted to check if "postal code", "cvv" and "country" are filled in subscription forms.
 We know they will be checked on server side on our setting but client validation is useful as follows:
 1) Improvement of user experience 
   When user submits form without "number" and "postal code", the form can show validation errors for both "number" and "postal code" at the same time, not just error for "number".
 2) The number of api calls can be reduced
   It can reduce the number of api calls in cases that "number" is filled but "postal code" is not filled.

**Caveat:**
 As you may have noticed, this depends on another PR #195. So if necessary, I will rebase this PR.

I may be missing something important, but this additional control would really help us. 
Thanks a lot :)
