### PR TITLE
update discount calculations to respect single_use coupons

### DIFF
--- a/lib/recurly/pricing/calculations.js
+++ b/lib/recurly/pricing/calculations.js
@@ -191,12 +191,12 @@ Calculations.prototype.discount = function () {
   if (coupon) {
     if (coupon.discount.rate) {
       var discountNow = parseFloat((this.price.now.subtotal * coupon.discount.rate).toFixed(6));
-      var discountNext = parseFloat((this.price.next.subtotal * coupon.discount.rate).toFixed(6));
+      var discountNext = coupon.single_use ? 0 : parseFloat((this.price.next.subtotal * coupon.discount.rate).toFixed(6));
       this.price.now.discount = Math.round(discountNow * 100) / 100;
       this.price.next.discount = Math.round(discountNext * 100) / 100;
     } else {
       this.price.now.discount = coupon.discount.amount[this.items.currency];
-      this.price.next.discount = coupon.discount.amount[this.items.currency];
+      this.price.next.discount = coupon.single_use ? 0 : coupon.discount.amount[this.items.currency];
     }
   }
 };

--- a/test/server/fixtures/plans/basic/coupons/coop-pct.json
+++ b/test/server/fixtures/plans/basic/coupons/coop-pct.json
@@ -3,5 +3,6 @@
   "name": "100% off!",
   "discount": {
     "rate": 1
-  }
+  },
+  "single_use": false
 }

--- a/test/server/fixtures/plans/basic/coupons/coop-single-use.json
+++ b/test/server/fixtures/plans/basic/coupons/coop-single-use.json
@@ -1,5 +1,5 @@
 {
-  "code": "coop",
+  "code": "coop-single-use",
   "name": "Test coupon with a long and silly name",
   "discount": {
     "type":"dollars",
@@ -7,5 +7,5 @@
       "USD": 20.0
     }
   },
-  "single_use": false
+  "single_use": true
 }

--- a/test/server/fixtures/plans/intermediate/coupons/coop-pct.json
+++ b/test/server/fixtures/plans/intermediate/coupons/coop-pct.json
@@ -3,5 +3,6 @@
   "name": "100% off!",
   "discount": {
     "rate": 1
-  }
+  },
+  "single_use": false
 }

--- a/test/server/fixtures/plans/intermediate/coupons/coop.json
+++ b/test/server/fixtures/plans/intermediate/coupons/coop.json
@@ -2,6 +2,10 @@
   "code": "coop",
   "name": "Test coupon with a long and silly name",
   "discount": {
-    "USD": 20.0
-  }
+    "type":"dollars",
+    "amount": {
+      "USD": 20.0
+    }
+  },
+  "single_use": false
 }

--- a/test/unit/coupon.test.js
+++ b/test/unit/coupon.test.js
@@ -63,7 +63,7 @@ helpers.apiTest(function (requestMethod) {
         it('contains a discount amount', function (done) {
           assertValidCoupon('coop', function (coupon) {
             assert(!coupon.discount.rate);
-            each(coupon.discount, function (currency, amount) {
+            each(coupon.discount.amount, function (currency, amount) {
               assert(currency.length === 3);
               assert(typeof amount === 'number');
             });

--- a/test/unit/pricing.test.js
+++ b/test/unit/pricing.test.js
@@ -129,4 +129,35 @@ describe('Recurly.Pricing', function () {
       });
   });
 
+  describe('with applied coupon', function () {
+    it('should apply multi-use coupon correctly', function (done) {
+      pricing
+        .plan('basic', { quantity: 1 })
+        .address({
+          country: 'US',
+          postal_code: 'NoTax'
+        })
+        .coupon('coop')
+        .done(function (price) {
+          assert.equal(price.now.discount, '20.00');
+          assert.equal(price.next.discount, '20.00');
+          done();
+        });
+    });
+
+    it('should apply single-use coupon correctly', function (done) {
+      pricing
+        .plan('basic', { quantity: 1 })
+        .address({
+          country: 'US',
+          postal_code: 'NoTax'
+        })
+        .coupon('coop-single-use')
+        .done(function (price) {
+          assert.equal(price.now.discount, '20.00');
+          assert.equal(price.next.discount, '0.00');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/recurly/recurly-js/issues/167

When calculating discount for coupons, check single_use property before applying discount to next invoice estimate.