### PR TITLE
Fixes an issue where XDRs aborted unpredictably

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -204,14 +204,19 @@ Recurly.prototype.xhr = function (method, route, data, done) {
     }
   };
 
-  if (method === 'post') {
-    // only available in XHR2 -- otherwise we are using XDR and cannot set Content-type
-    if (req.setRequestHeader) {
-      req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+  // XDR requests will abort if too many are sent simultaneously
+  setTimeout(send, 0);
+
+  function send () {
+    if (method === 'post') {
+      // XDR cannot set Content-type
+      if (req.setRequestHeader) {
+        req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+      }
+      req.send(payload);
+    } else {
+      req.send();
     }
-    req.send(payload);
-  } else {
-    req.send();
   }
 };
 


### PR DESCRIPTION
- XDRs are known to abort if too many are sent simultaneously
- This allows sends to execute asynchronously from their setup and space apart more.
- This will fix intermittent IE9 test failures
- See note on https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest