### PR TITLE
Check if cvv is required before ignoring empty value

### DIFF
--- a/lib/recurly/token.js
+++ b/lib/recurly/token.js
@@ -124,7 +124,7 @@ function validate (input) {
     errors.push('last_name');
   }
 
-  if (input.cvv && !this.validate.cvv(input.cvv)) {
+  if ((~index(this.config.required, 'cvv') || input.cvv) && !this.validate.cvv(input.cvv)) {
     errors.push('cvv');
   }
 

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -65,7 +65,7 @@ describe('Recurly.validate', function () {
     });
 
     it('should return true for leading zeros', function() {
-      assert(true === recurly.validate.expiry('01', '16'));
+      assert(true === recurly.validate.expiry('01', '19'));
     });
 
     it('should return false for invalid dates', function() {


### PR DESCRIPTION
When validating input values, check if cvv is present in required fields before skipping an empty value.