### PR TITLE
Reconnects bus after reset (fixes field integrity check)

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -154,10 +154,7 @@ export class Recurly extends Emitter {
       return;
     }
 
-    if (this.bus) {
-      this.bus.reset();
-      this.bus.connect();
-    }
+    if (this.bus) this.bus.reset();
     else this.bus = new Bus;
 
     this.bus.add(this);

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -154,7 +154,10 @@ export class Recurly extends Emitter {
       return;
     }
 
-    if (this.bus) this.bus.reset();
+    if (this.bus) {
+      this.bus.reset();
+      this.bus.connect();
+    }
     else this.bus = new Bus;
 
     this.bus.add(this);

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -84,6 +84,6 @@ export class Bus extends Emitter {
   reset () {
     this.recipients = [];
     window.removeEventListener('message', this.receive, false);
-    connect ();
+    this.connect ();
   }
 }

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -77,12 +77,13 @@ export class Bus extends Emitter {
   /**
    * Resets the bus
    *  - Empties recipients
-   *  - disconnects listener
+   *  - cycles listener
    *
    * @public
    */
   reset () {
     this.recipients = [];
     window.removeEventListener('message', this.receive, false);
+    connect ();
   }
 }


### PR DESCRIPTION
The bus.reset() call was removing the event listener -- this patch just reconnects it.

Please note my environment isn't set up to run the test suite on this, but it works well for my use case.