### PR TITLE
Emits a pricing error when a coupon is not found

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,18 @@ var staticConfig = {
   concurrency: Infinity,
   browserDisconnectTimeout: 300000, // 5 minutes
   browserNoActivityTimeout: 300000,
-  captureTimeout: 300000
+  captureTimeout: 300000,
+  customLaunchers: {
+    PhantomJSDebug: {
+      base: 'PhantomJS',
+      debug: true
+    }
+  },
+  client: {
+    mocha: {
+      grep: ''
+    }
+  }
 };
 
 var runner = function (config) {

--- a/lib/recurly/pricing/attach.js
+++ b/lib/recurly/pricing/attach.js
@@ -60,7 +60,7 @@ export function attach (el) {
     }
 
     if (elems.coupon && (target('coupon') || target('plan'))) {
-      pricing = pricing.coupon(dom.value(elems.coupon)).then(null, ignoreBadCoupons);
+      pricing = pricing.coupon(dom.value(elems.coupon).trim()).then(null, ignoreBadCoupons);
     }
 
     if (target('country') || target('postal_code')) {

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -267,13 +267,14 @@ Pricing.prototype.coupon = function (couponCode, done) {
 
   function setCoupon (coupon) {
     debug('set.coupon');
-    self.emit('set.coupon', coupon);
     self.items.coupon = coupon;
+    self.emit('set.coupon', coupon);
   }
 
   function unsetCoupon (err) {
     debug('unset.coupon');
     delete self.items.coupon;
+    self.emit('unset.coupon');
   }
 };
 

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -78,7 +78,7 @@ Pricing.prototype.remove = function (opts, done) {
   return new PricingPromise(function (resolve, reject) {
     var prop = keys(opts)[0];
     var id = opts[prop];
-    if (!~index(Pricing.properties, prop)) return reject(errors('invalid-item'));
+    if (!~index(Pricing.properties, prop)) return self.error(errors('invalid-item'), reject);
     if (prop === 'addon') {
       var pos = index(self.items.addons, findAddon(self.items.addons, { code: id }));
       if (~pos) {
@@ -88,11 +88,11 @@ Pricing.prototype.remove = function (opts, done) {
       item = self.items[prop];
       delete self.items[prop];
     } else {
-      return reject(errors('unremovable-item', {
+      return self.error(errors('unremovable-item', {
         type: prop,
         id: id,
         reason: 'does not exist on this pricing instance.'
-      }));
+      }), reject);
     }
   }, this).nodeify(done);
 };
@@ -109,7 +109,7 @@ Pricing.prototype.reprice = function (done) {
   debug('reprice');
 
   return new PricingPromise(function (resolve, reject) {
-    if (!self.items.plan) return reject(errors('missing-plan'));
+    if (!self.items.plan) return self.error(errors('missing-plan'), reject, 'plan');
 
     Calculations(self, function (price) {
       if (JSON.stringify(price) === JSON.stringify(self.price)) return resolve(price);
@@ -154,7 +154,7 @@ Pricing.prototype.plan = function (planCode, meta, done) {
     }
 
     self.recurly.plan(planCode, function (err, plan) {
-      if (err) return reject(err);
+      if (err) return self.error(err, reject, 'plan');
 
       plan.quantity = quantity;
       self.items.plan = plan;
@@ -200,14 +200,14 @@ Pricing.prototype.addon = function (addonCode, meta, done) {
   meta = meta || {};
 
   return new PricingPromise(function (resolve, reject) {
-    if (!self.items.plan) return reject(errors('missing-plan'));
+    if (!self.items.plan) return self.error(errors('missing-plan'), reject, 'addon');
 
     var planAddon = findAddon(self.items.plan.addons, addonCode);
     if (!planAddon) {
-      return reject(errors('invalid-addon', {
+      return self.error(errors('invalid-addon', {
         planCode: self.items.plan.code,
         addonCode: addonCode
-      }));
+      }), reject, 'addon');
     }
 
     var quantity = addonQuantity(meta, planAddon);
@@ -244,27 +244,37 @@ Pricing.prototype.coupon = function (couponCode, done) {
   var coupon = this.items.coupon;
 
   return new PricingPromise(function (resolve, reject) {
-    if (!self.items.plan) return reject(errors('missing-plan'));
+    if (!self.items.plan) return self.error(errors('missing-plan'), reject, 'coupon');
     if (coupon) self.remove({ coupon: coupon.code });
 
-    // TODO: Should this emit an 'unset' event?
-    // Need to consider other objects as well
+    // A blank coupon is handled as ok
     if (!couponCode) {
-      debug('unset.coupon');
-      delete self.items.coupon;
+      unsetCoupon();
       return resolve();
     }
 
     self.recurly.coupon({ plan: self.items.plan.code, coupon: couponCode }, function (err, coupon) {
-      if (err && err.code !== 'not-found') return reject(err);
+      if (err && err.code === 'not-found') unsetCoupon();
 
-      self.items.coupon = coupon;
-
-      debug('set.coupon');
-      self.emit('set.coupon', coupon);
-      resolve(coupon);
+      if (err) {
+        return self.error(err, reject, 'coupon');
+      } else {
+        setCoupon(coupon);
+        resolve(coupon);
+      }
     });
   }, this).nodeify(done);
+
+  function setCoupon (coupon) {
+    debug('set.coupon');
+    self.emit('set.coupon', coupon);
+    self.items.coupon = coupon;
+  }
+
+  function unsetCoupon (err) {
+    debug('unset.coupon');
+    delete self.items.coupon;
+  }
 };
 
 /**
@@ -279,7 +289,7 @@ Pricing.prototype.coupon = function (couponCode, done) {
  */
 
 Pricing.prototype.address = function (address, done) {
-  return new PricingPromise(this.updateFactory('address', address), this).nodeify(done);
+  return new PricingPromise(updateFactory(this, 'address', address), this).nodeify(done);
 };
 
 /**
@@ -293,7 +303,7 @@ Pricing.prototype.address = function (address, done) {
  */
 
 Pricing.prototype.tax = function (tax, done) {
-  return new PricingPromise(this.updateFactory('tax', tax), this).nodeify(done);
+  return new PricingPromise(updateFactory(this, 'tax', tax), this).nodeify(done);
 };
 
 /**
@@ -312,10 +322,10 @@ Pricing.prototype.currency = function (code, done) {
   return new PricingPromise(function (resolve, reject) {
     if (currency === code) return resolve(currency);
     if (plan && !(code in plan.price)) {
-      return reject(errors('invalid-currency', {
+      return self.error(errors('invalid-currency', {
         currencyCode: code,
         planCurrencies: keys(plan.price)
-      }));
+      }), reject, 'currency');
     }
 
     self.items.currency = code;
@@ -326,20 +336,19 @@ Pricing.prototype.currency = function (code, done) {
   }, this).nodeify(done);
 };
 
-Pricing.prototype.updateFactory = function (name, object) {
-  var self = this;
-
-  return function (resolve, reject) {
-    if (JSON.stringify(object) === JSON.stringify(self.items[name])) {
-      return resolve(self.items[name]);
-    }
-
-    self.items[name] = object;
-
-    debug(`set.${name}`);
-    self.emit(`set.${name}`, object);
-    resolve(object);
-  };
+/**
+ * Emits an namespaced errors
+ * @param  {Error}    error
+ * @param  {Function} reject     Promise rejection function
+ * @param  {[String]} namespace  dot-delimited error namespace
+ * @private
+ */
+Pricing.prototype.error = function (error, reject, namespace) {
+  if (namespace) {
+    namespace.split('.').reduce((memo, name) => this.emit(`${memo}.${name}`, error), 'error');
+  }
+  this.emit('error', error);
+  return reject(error);
 };
 
 /**
@@ -357,6 +366,20 @@ module.exports = exports = Pricing;
 /**
  * Utility functions
  */
+
+function updateFactory (self, name, object) {
+  return (resolve, reject) => {
+    if (JSON.stringify(object) === JSON.stringify(self.items[name])) {
+      return resolve(self.items[name]);
+    }
+
+    self.items[name] = object;
+
+    debug(`set.${name}`);
+    self.emit(`set.${name}`, object);
+    resolve(object);
+  };
+}
 
 function addonQuantity (meta, planAddon) {
   var qty = 1;

--- a/test/pricing/pricing.test.js
+++ b/test/pricing/pricing.test.js
@@ -189,5 +189,19 @@ describe('Recurly.Pricing', function () {
           done();
         });
     });
+
+    it('emits an error event when a coupon is not found', function (done) {
+      this.pricing
+        .on('error.coupon', function (err) {
+          assert(err.code === 'not-found');
+          done();
+        })
+        .plan('basic', { quantity: 1 })
+        .address({
+          country: 'US',
+          postal_code: 'NoTax'
+        })
+        .coupon('coop-invalid');
+    });
   });
 });

--- a/test/pricing/pricing.test.js
+++ b/test/pricing/pricing.test.js
@@ -203,5 +203,25 @@ describe('Recurly.Pricing', function () {
         })
         .coupon('coop-invalid');
     });
+
+    it('emits an unset event when a coupon is cleared', function (done) {
+      let emitted = false;
+      this.pricing
+        .on('unset.coupon', () => emitted = true)
+        .plan('basic', { quantity: 1 })
+        .address({
+          country: 'US',
+          postal_code: 'NoTax'
+        })
+        .coupon('coop')
+        .then((coupon) => assert(coupon.code === 'coop'))
+        .coupon('')
+        .then((coupon) => assert(!coupon))
+        .done(function (price) {
+          assert.equal(price.now.discount, '0.00');
+          assert(emitted, true);
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
- Still sets the not found coupon, consistent with current behavior
- Fixes #262 

```js
let pricing = recurly.Pricing();
pricing.attach(form);
pricing.on('error.coupon', function (err) {
  // err.code === 'not-found'
});
```

```js
let pricing = recurly.Pricing()
  .plan('basic')
  .coupon('invalid')
  .catch(function (err) {
    // err.code === 'not-found'
  });
```

##### Bonuses

- Adds the 'unset.coupon' event to pricing instances
- Adds debugger to default karma runner