### PR TITLE
Enables CORS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,28 +39,6 @@ If you are having issues with the build, try `make clean`.
 $ make test
 ```
 
-## Additional Features
-
-### XHR+CORS
-
-As of v3.0.9, Recurly.js supports API communication using
-Cross-Origin Resource Sharing over XMLHttpRequest, as opposed
-to the traditional method of JSONP. A later version of Recurly.js will
-switch over to using CORS+XHR exclusively, but if you would like to test
-out this feature first, you may enable it by setting the `cors` configuration
-property to `true`.
-
-```js
-recurly.configure({
-  publicKey: 'YOUR PUBLIC KEY',
-  cors: true
-});
-```
-
-Please note that in order to use this feature in IE9, you must serve your
-payment page over HTTPS. This is a known limitation of the CORS implementation
-in IE9.
-
 ## License
 
 [MIT][license]

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -36,7 +36,7 @@ const defaults = {
   timeout: 60000,
   publicKey: '',
   parent: true,
-  cors: false,
+  cors: true,
   fraud: {
     kount: { dataCollector: false },
     litle: { sessionId: null }

--- a/lib/recurly/fraud.js
+++ b/lib/recurly/fraud.js
@@ -1,11 +1,14 @@
 import each from 'component-each';
+import Emitter from 'component-emitter';
 import dom from '../util/dom';
 import errors from '../errors';
 
 const debug = require('debug')('recurly:fraud');
 
-export class Fraud {
+export class Fraud extends Emitter {
   constructor (recurly) {
+    super();
+
     this.recurly = recurly;
     this.selector = this.recurly.config.fields.number;
     this.dataCollectorInitiated = false;
@@ -56,6 +59,7 @@ export class Fraud {
         throw errors('fraud-data-collector-request-failed', { error });
       } else if (response.content) {
         this.addNodes(response.content);
+        this.emit('ready');
       }
     });
   }

--- a/test/pricing/attachment.test.js
+++ b/test/pricing/attachment.test.js
@@ -22,6 +22,7 @@ describe('Recurly.Pricing.attach', function () {
 
   describe('when given a container', function () {
     this.ctx.fixture = 'pricing';
+    this.ctx.fixtureOpts = { plan: 'basic' };
 
     beforeEach(function () {
       assert(typeof this.pricing.attachment === 'undefined');
@@ -35,10 +36,7 @@ describe('Recurly.Pricing.attach', function () {
     });
 
     describe('when pre-populated with a valid coupon code', function () {
-      this.ctx.fixtureOpts = {
-        plan: 'basic',
-        coupon: 'coop'
-      };
+      this.ctx.fixtureOpts = { plan: 'basic', coupon: 'coop' };
 
       it('applies the coupon to the pricing instance', function (done) {
         assert(typeof this.pricing.items.coupon === 'undefined');

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -11,8 +11,8 @@ export function initRecurly (opts) {
 }
 
 export function apiTest (suite) {
-  suite('jsonp');
   suite('cors');
+  suite('jsonp');
 }
 
 export function domTest (suite) {

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -209,9 +209,7 @@ apiTest(requestMethod => {
 
         it('sends a fraud session id and yields a token', function (done) {
           const example = merge(clone(valid), { fraud_session_id: '9a87s6dfaso978ljk' });
-          // HACK: This gives the fraud data collector time to inject.
-          // SOLUTION: recurly.readyState needs to be replaced with an init registry
-          setTimeout(() => {
+          this.recurly.fraud.on('ready', () => {
             this.recurly.token(builder(example), (err, token) => {
               const spy = this.recurly.bus.send.withArgs('token:init');
               assert(spy.calledOnce);
@@ -222,7 +220,7 @@ apiTest(requestMethod => {
               assert(token);
               done();
             });
-          }, 500);
+          });
         });
       });
 


### PR DESCRIPTION
- 🍺 
- Also removes a `setTimeout` from the fraud tests, ~20% test speed increase