### PR TITLE
Allows a label tag paired to a field container to defer focus to the field

### DIFF
--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -1,4 +1,5 @@
 import Emitter from 'component-emitter';
+import events from 'component-event';
 import dom from '../util/dom';
 import errors from '../errors';
 
@@ -17,16 +18,25 @@ export class HostedField extends Emitter {
   constructor (options) {
     super();
 
+    this.focus = this.focus.bind(this);
+    this.onBlur = this.onBlur.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+
     this.isFocused = false;
     this.configure(options);
     this.inject();
+    this.bindLabel();
 
-    this.on('bus:added', bus => bus.add(this.window));
+    this.on('bus:added', bus => {
+      this.bus = bus;
+      this.bus.add(this.window);
+    });
 
     // TODO: need these to be specific to this instance
-    this.on('hostedField:focus', this.focus.bind(this));
-    this.on('hostedField:blur', this.blur.bind(this));
-    this.on('hostedField:change', this.change.bind(this));
+    this.on('hostedField:focus', this.onFocus.bind(this));
+    this.on('hostedField:blur', this.onBlur.bind(this));
+    this.on('hostedField:change', this.onChange.bind(this));
   }
 
   get type () {
@@ -34,7 +44,7 @@ export class HostedField extends Emitter {
   }
 
   configure (options) {
-    this.target = dom.element(window.document.querySelector(options.selector));
+    this.target = dom.element(global.document.querySelector(options.selector));
     if (!this.target) {
       const {type, selector} = options;
       throw errors('missing-hosted-field-target', { type, selector });
@@ -64,25 +74,38 @@ export class HostedField extends Emitter {
     this.iframe.style.background = 'transparent';
   }
 
+  bindLabel () {
+    if (!this.target.id) return;
+    const labels = global.document.querySelectorAll(`label[for=${this.target.id}]`);
+    [].slice.apply(labels).forEach(label => {
+      events.bind(label, 'click', this.focus);
+    });
+  }
+
   update () {
     this.container.className = this.classList();
   }
 
-  focus (body) {
+  onFocus (body) {
     if (body.type !== this.type) return;
     this.isFocused = true;
     this.update();
   }
 
-  blur (body) {
+  onBlur (body) {
     if (body.type !== this.type) return;
     this.isFocused = false;
     this.update();
   }
 
-  change (body) {
+  onChange (body) {
     if (body.type !== this.type) return;
     this.update();
+  }
+
+  focus () {
+    if (!this.bus) return;
+    this.bus.send(`hostedField:${this.type}:focus!`);
   }
 
   classList () {


### PR DESCRIPTION
- Finds labels paired to containers via for-id match
- Sends `hostedField:${type}:focus!` event when label is clicked/tapped
- This will not work with mobile Safari due to strict focus event constraints. See [this][so]
- Fixes #240
- Fixes #271

[so]: http://stackoverflow.com/questions/12204571/mobile-safari-javascript-focus-method-on-inputfield-only-works-with-click#answer-16601288