### PR TITLE
Adds safety check to dom value get method

### DIFF
--- a/lib/util/dom.js
+++ b/lib/util/dom.js
@@ -80,7 +80,8 @@ function valueGet (node) {
   if (!nodeType) {
     value = '';
   } else if ('options' in node) {
-    value = node.options[node.selectedIndex].value;
+    let option = node.options[node.selectedIndex] || node.options[0] || { value: '' };
+    value = option.value;
   } else if (nodeType === 'checkbox') {
     if (node.checked) value = node.value;
   } else if (nodeType === 'radio') {


### PR DESCRIPTION
- If a merchant uses a select input with no options in a pricing attachment (see example below), the `valueGet` function would blow up as described in #220.
- Fixes #220

```html
<form>
  <select data-recurly="plan">
  </select>
</form>
```

```js
let pricing = recurly.Pricing();
pricing.attach(document.querySelector('form'));

// ... retrieve plans asynchronously and add options to the plan select input
```