### PR TITLE
Add support for tabbing in a Mobile browser.

### DIFF
--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -28,6 +28,7 @@ export class HostedField extends Emitter {
     this.configure(options);
     this.inject();
     this.bindLabel();
+    this.bindTabTrap();
 
     this.on('bus:added', bus => {
       this.bus = bus;
@@ -69,11 +70,14 @@ export class HostedField extends Emitter {
 
   inject () {
     this.target.innerHTML = `
-      <div class="${this.classList()}">
+      <div class="${this.classList()}" style="position:relative;">
+        <input type="text" style="position: absolute; z-index: -1; width: 0; height: 0;" data-recurly-hosted-field="true" />
         <iframe
           src="${this.url()}"
+          data-recurly-iframe="true"
           border="0"
           frameborder="0"
+          tabIndex="-1"
           allowtransparency="true"
           scrolling="no">
         </iframe>
@@ -81,12 +85,15 @@ export class HostedField extends Emitter {
     `;
 
     this.container = this.target.children[0];
-    this.iframe = this.container.children[0];
+    this.tabTrapInput = this.container.children[0];
+    this.iframe = this.container.children[1];
     this.window = this.iframe.contentWindow;
 
     this.iframe.style.height = '100%';
     this.iframe.style.width = '100%';
     this.iframe.style.background = 'transparent';
+    this.iframe.style.position = 'relative';
+    this.iframe.style.zIndex = 1;
   }
 
   bindLabel () {
@@ -100,9 +107,22 @@ export class HostedField extends Emitter {
   reset () {
     this.off();
     this.target.innerHTML = '';
+    // TODO: May need to remove tabTrap stuff
     delete this.target;
     delete this.iframe;
     delete this.window;
+  }
+
+  bindTabTrap () {
+    this.tabTrapInput.addEventListener('focus',e => {
+      e.preventDefault()
+      e.stopPropagation()
+      // Firefox demands a blur or else the focus doesn' work...
+      if(navigator.userAgent.toLowerCase().indexOf('firefox') >= 0){
+        e.currentTarget.blur()
+      }
+      this.focus()
+    })
   }
 
   update () {

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -2,8 +2,11 @@ import clone from 'component-clone';
 import Emitter from 'component-emitter';
 import merge from 'lodash.merge';
 import omit from 'lodash.omit';
+import indexOf from 'lodash.indexof'
 import {HostedField} from './hosted-field';
 import errors from '../errors';
+
+const FOCUS_SELECTOR = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe:not([data-recurly-iframe]), object, embed, [tabindex="0"], [contenteditable]';
 
 const debug = require('debug')('recurly:hostedFields');
 
@@ -37,6 +40,43 @@ export class HostedFields extends Emitter {
       this.bus = bus;
       this.fields.forEach(hf => bus.add(hf));
     });
+
+    this.on('hostedField:tab:previous',this.onTabPrevious.bind(this))
+    this.on('hostedField:tab:next',this.onTabNext.bind(this))
+  }
+
+  onTabNext(body) {
+    let type = body.type;
+    let field = this.fields.find(f => f.type === type);
+    let tabTrap = field.tabTrapInput;
+    let allFields = document.querySelectorAll(FOCUS_SELECTOR);
+    let curIdx = indexOf(allFields,tabTrap);
+
+    if(curIdx+1 < allFields.length){
+      let nextIdx = curIdx + 1;
+      let nextEl = allFields[nextIdx];
+      this.tabToElement(field,nextIdx,nextEl);
+    }
+  }
+
+  onTabPrevious(body) {
+    let type = body.type;
+    let field = this.fields.find(f => f.type === type);
+    let tabTrap = field.tabTrapInput;
+    let allFields = document.querySelectorAll(FOCUS_SELECTOR);
+    let curIdx = indexOf(allFields,tabTrap);
+
+    if(curIdx-1 > 0){
+      let prevIdx = curIdx - 1;
+      let prevEl = allFields[prevIdx];
+      this.tabToElement(field,prevIdx,prevEl);
+    }
+  }
+
+  tabToElement(focusedField,index,element) {
+    let elementIsHosted = typeof element.attributes["data-recurly-hosted-field"] !== "undefined";
+    focusedField.iframe.blur()
+    element.focus()
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "debug": "2.2.0",
     "json-component": "0.0.1",
     "jsonp": "0.0.4",
+    "lodash.indexof": "^4.0.5",
     "lodash.map": "^4.6.0",
     "lodash.merge": "*",
     "lodash.omit": "*",


### PR DESCRIPTION
This PR does 2 things to add mobile tabbing between hosted fields support.

1) Adds a "hidden" input before the iFrame. iOS Safari at least doesn't tab into the iframe like most desktop browsers do. The hidden input just transfers the focus from itself to the hosted field inside.

2) Adds support for hostedField:tab:previous and hostedField:tab:next events. These events just grab all [data-recurly] elements (either actual input fields or a div containing a hosted field), and then transfer focus to whichever one is previous or next.
