### PR TITLE
Sends initial field config over hash instead of query

### DIFF
--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -123,6 +123,6 @@ export class HostedField extends Emitter {
 
   url () {
     let config = encodeURIComponent(JSON.stringify(this.config));
-    return `${this.config.recurly.api}/field?config=${config}`;
+    return `${this.config.recurly.api}/field.html#config=${config}`;
   }
 }

--- a/test/server/fixtures/field.html.ejs
+++ b/test/server/fixtures/field.html.ejs
@@ -45,7 +45,7 @@
     }
 
     function config () {
-      var query = window.location.search;
+      var query = window.location.hash;
       return JSON.parse(decodeURIComponent(query.substring(query.indexOf('config=') + 7)) || {});
     }
 

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -34,6 +34,7 @@ app.use(route.get('/tax', json));
 app.use(route.get('/paypal/start', postMessage));
 app.use(route.get('/relay', render('relay')));
 app.use(route.get('/field', render('field')));
+app.use(route.get('/field.html', render('field')));
 app.use(route.get('/fraud_data_collector', json));
 
 app.listen(port, () => {


### PR DESCRIPTION
- This will let us cache those responses more aggressively