### PR TITLE
Adds support for shipping address

### DIFF
--- a/lib/recurly/pricing/attachment.js
+++ b/lib/recurly/pricing/attachment.js
@@ -59,11 +59,12 @@ export default class Attachment {
     const target = event.target || event.srcElement;
     const targetName = dom.data(target, 'recurly');
     const updating = name => event === INIT_RUN || targetName === name;
-    const updateAddress = updating('country') || updating('postal_code');
     const updateAddon = elems.addon && updating('addon');
+    const updateAddress = updating('country') || updating('postal_code');
     const updateCurrency = updating('currency');
     const updateCoupon = elems.coupon && (updating('coupon') || updating('plan'));
     const updateGiftcard = elems.gift_card && updating('gift_card');
+    const updateShippingAddress = updating('shipping_address.country') || updating('shipping_address.postal_code');
     const updateTax = updating('vat_number') || updating('tax_code');
 
     let pricing = this.pricing.plan(dom.value(elems.plan), { quantity: dom.value(elems.plan_quantity) });
@@ -94,11 +95,18 @@ export default class Attachment {
       pricing = pricing.giftcard(dom.value(elems.gift_card).trim()).then(null, ignoreNotFound);
     }
 
-    if (updateAddress) {
-      pricing = pricing.address({
-        country: dom.value(elems.country),
-        postal_code: dom.value(elems.postal_code)
-      });
+    if (updateShippingAddress || updateAddress) {
+      if ('shipping_address.country' in elems || 'shipping_address.postal_code' in elems) {
+        pricing = pricing.shippingAddress({
+          country: dom.value(elems['shipping_address.country']),
+          postal_code: dom.value(elems['shipping_address.postal_code'])
+        });
+      } else {
+        pricing = pricing.address({
+          country: dom.value(elems.country),
+          postal_code: dom.value(elems.postal_code)
+        });
+      }
     }
 
     if (updateTax) {

--- a/lib/recurly/pricing/attachment.js
+++ b/lib/recurly/pricing/attachment.js
@@ -95,18 +95,18 @@ export default class Attachment {
       pricing = pricing.giftcard(dom.value(elems.gift_card).trim()).then(null, ignoreNotFound);
     }
 
-    if (updateShippingAddress || updateAddress) {
-      if ('shipping_address.country' in elems || 'shipping_address.postal_code' in elems) {
-        pricing = pricing.shippingAddress({
-          country: dom.value(elems['shipping_address.country']),
-          postal_code: dom.value(elems['shipping_address.postal_code'])
-        });
-      } else {
-        pricing = pricing.address({
-          country: dom.value(elems.country),
-          postal_code: dom.value(elems.postal_code)
-        });
-      }
+    if (updateAddress) {
+      pricing = pricing.address({
+        country: dom.value(elems.country),
+        postal_code: dom.value(elems.postal_code)
+      });
+    }
+
+    if (updateShippingAddress) {
+      pricing = pricing.shippingAddress({
+        country: dom.value(elems['shipping_address.country']),
+        postal_code: dom.value(elems['shipping_address.postal_code'])
+      });
     }
 
     if (updateTax) {

--- a/lib/recurly/pricing/calculations.js
+++ b/lib/recurly/pricing/calculations.js
@@ -85,6 +85,8 @@ Calculations.prototype.subtotal = function () {
 /**
  * Calculates tax
  *
+ * tax info precedence: `tax` > `shipping_address` > `address`
+ *
  * @param {Function} done
  * @private
  */

--- a/lib/recurly/pricing/calculations.js
+++ b/lib/recurly/pricing/calculations.js
@@ -93,7 +93,8 @@ Calculations.prototype.tax = function (done) {
   this.price.now.tax = 0;
   this.price.next.tax = 0;
 
-  var taxInfo = merge({}, this.items.address);
+  const address = this.items.shipping_address || this.items.address;
+  const taxInfo = merge({}, address);
 
   merge(taxInfo, this.items.tax);
 

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -14,7 +14,8 @@ const PROPERTIES = [
   'coupon',
   'address',
   'currency',
-  'gift_card'
+  'gift_card',
+  'shipping_address'
 ];
 
 /**
@@ -339,6 +340,21 @@ export default class Pricing extends Emitter {
 
   address (address, done) {
     return new PricingPromise(updateFactory(this, 'address', address), this).nodeify(done);
+  }
+
+  /**
+   * Updates shipping address
+   *
+   * @param {Object} address
+   * @param {String} address.country
+   * @param {String|Number} address.postal_code
+   * @param {String} address.vat_number
+   * @param {Function} [done] callback
+   * @public
+   */
+
+  shippingAddress (address, done) {
+    return new PricingPromise(updateFactory(this, 'shipping_address', address), this).nodeify(done);
   }
 
   /**

--- a/lib/recurly/pricing/promise.js
+++ b/lib/recurly/pricing/promise.js
@@ -19,7 +19,8 @@ const pricingMethods = [
   'reset',
   'remove',
   'reprice',
-  'giftcard'
+  'giftcard',
+  'shippingAddress'
 ];
 
 /**

--- a/test/pricing/attachment.test.js
+++ b/test/pricing/attachment.test.js
@@ -47,13 +47,47 @@ describe('Recurly.Pricing.attach', function () {
       });
     });
 
-    describe('when pre-populated with a valid giftcard redemption code', function(){
+    describe('when given an address', function () {
+      this.ctx.fixtureOpts = {
+        plan: 'basic',
+        country: 'US',
+        postal_code: '94129'
+      };
+
+      it('sets the address', function (done) {
+        assert(typeof this.pricing.items.address === 'undefined');
+        this.pricing.on('set.address', () => {
+          assert(this.pricing.items.address.country === 'US');
+          assert(this.pricing.items.address.postal_code === '94129');
+          done();
+        });
+      });
+    });
+
+    describe('when given a shipping address', function () {
+      this.ctx.fixtureOpts = {
+        plan: 'basic',
+        'shipping_address.country': 'US',
+        'shipping_address.postal_code': '94129'
+      };
+
+      it('sets the shipping address', function (done) {
+        assert(typeof this.pricing.items.shipping_address === 'undefined');
+        this.pricing.on('set.shipping_address', () => {
+          assert(this.pricing.items.shipping_address.country === 'US');
+          assert(this.pricing.items.shipping_address.postal_code === '94129');
+          done();
+        });
+      });
+    });
+
+    describe('when pre-populated with a valid giftcard redemption code', function () {
       this.ctx.fixtureOpts = {
         plan: 'basic',
         giftcard: 'superGiftcardForMe'
       };
 
-      it('applies the giftcard to the pricing instance', function(done) {
+      it('applies the giftcard to the pricing instance', function (done) {
         assert(typeof this.pricing.items.gift_card === 'undefined');
         this.pricing.on('set.gift_card', () => {
           assert(this.pricing.items.gift_card.currency === 'USD');

--- a/test/pricing/pricing.test.js
+++ b/test/pricing/pricing.test.js
@@ -139,6 +139,46 @@ describe('Recurly.Pricing', function () {
           done();
         });
     });
+
+    describe('with a shipping address', function () {
+      it('calculates tax from the shipping address', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .shippingAddress({
+            country: 'US',
+            postal_code: '94129'
+          })
+          .done(function (price) {
+            assert.equal(price.taxes.length, 1);
+            assert.equal(price.taxes[0].type, 'us');
+            assert.equal(price.taxes[0].rate, '0.0875');
+            assert.equal(price.now.tax, '1.93');
+            assert.equal(price.next.tax, '1.75');
+            done();
+          });
+      });
+
+      it('calculates tax from the shipping address when a billing address is given', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .address({
+            country: 'DE',
+            postal_code: 'XXX-XXX'
+          })
+          .shippingAddress({
+            country: 'US',
+            postal_code: '94129'
+          })
+          .done(function (price) {
+            assert.equal(price.taxes.length, 1);
+            assert.equal(price.taxes[0].type, 'us');
+            assert.equal(price.taxes[0].rate, '0.0875');
+            assert.equal(price.now.tax, '1.93');
+            assert.equal(price.next.tax, '1.75');
+            done();
+          });
+      })
+    });
   });
 
   describe('with usage addons', function() {

--- a/test/support/fixtures.js
+++ b/test/support/fixtures.js
@@ -65,6 +65,9 @@ const pricing = opts => `
     <input type="text" data-recurly="tax_code" value="${fetch(opts, 'tax_code', '')}">
     <input type="text" data-recurly="vat_number" value="${fetch(opts, 'vat_number', '')}">
 
+    <input type="text" data-recurly="shipping_address.country" value="${fetch(opts, 'shipping_address.country', '')}">
+    <input type="text" data-recurly="shipping_address.postal_code" value="${fetch(opts, 'shipping_address.postal_code', '')}">
+
     <span data-recurly="total_now"></span>
     <span data-recurly="subtotal_now"></span>
     <span data-recurly="addons_now"></span>


### PR DESCRIPTION
- Adds pricing class support for shipping address
- Adds attachment procedure for shipping address
- Establishes that shipping address holds precedence for billing address in tax calculations

#### Pricing API updates

```js
let pricing = recurly.Pricing();
pricing.plan('basic', { quantity: 1 })
  .address({
    country: 'DE'
  })
  .shippingAddress({
    country: 'US',
    postal_code: '94129',
    vat_number: ''
  })
  .done(function (price) {
    // will calculate taxes based on shipping address and not (billing) address
  });
```

#### New pricing elements

```html
<input data-recurly="shipping_address.country" type="text">
<input data-recurly="shipping_address.postal_code" type="text">
```