### PR TITLE
Ensures configuration objects are not externally mutable

### DIFF
--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -1,6 +1,6 @@
 import Emitter from 'component-emitter';
 import events from 'component-event';
-import MutationObserver from 'mutation-observer';
+import clone from 'component-clone';
 import dom from '../util/dom';
 import errors from '../errors';
 
@@ -58,6 +58,7 @@ export class HostedField extends Emitter {
   // Private
 
   configure (options) {
+    options = clone(options);
     this.target = dom.element(global.document.querySelector(options.selector));
     if (!this.target) {
       const {type, selector} = options;

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -1,6 +1,7 @@
-import omit from 'lodash.omit';
-import merge from 'lodash.merge';
+import clone from 'component-clone';
 import Emitter from 'component-emitter';
+import merge from 'lodash.merge';
+import omit from 'lodash.omit';
 import {HostedField} from './hosted-field';
 import errors from '../errors';
 
@@ -53,7 +54,7 @@ export class HostedFields extends Emitter {
   // Private
 
   configure (options) {
-    this.config = options || {};
+    this.config = clone(options || {});
   }
 
   inject () {


### PR DESCRIPTION
- Fixes issue where external configuration assignments could undermine integrity checks
