### PR TITLE
Include the responseText when json is invalid

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -307,7 +307,7 @@ export class Recurly extends Emitter {
         res = JSON.parse(this.responseText);
       } catch (e) {
         debug(this.responseText, e);
-        return done(errors('api-error', { message: 'There was a problem parsing the API response.' }));
+        return done(errors('api-error', { message: `There was a problem parsing the API response with: ${this.responseText}` }));
       }
 
       if (res && res.error) {

--- a/test/server/fixtures/token/index.js
+++ b/test/server/fixtures/token/index.js
@@ -9,10 +9,12 @@
  */
 
 var DECLINE_CARD = '4000000000000002';
+var INVALID_JSON = '5454545454545454';
 
 module.exports = function token () {
   var params = this.method === 'GET' ? this.query : this.request.body;
   if (params.number === DECLINE_CARD) return decline;
+  if (params.number === INVALID_JSON) return invalidJson;
   else return ok;
 };
 
@@ -23,6 +25,13 @@ module.exports = function token () {
 var ok = {
   id: "7QF5CSJ2n-6CXX1k15FtYA"
 };
+
+/**
+ * If the api returns a responseText that isn't valid json
+ */
+
+var invalidJson = 'some json that cannot be parsed';
+
 
 /**
  * card decline error. could be due to invalid nubmer, cvv, exp date

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -126,7 +126,7 @@ apiTest(requestMethod => {
 
         it('produces a validation error', function (done) {
           this.recurly.token(builder(example), (err, token) => {
-            assert(err.code === 'declined')
+            assert(err.code === 'declined');
             assert(err.message.indexOf('card was declined'));
             assert(err.fields.length === 1);
             assert(err.fields[0] === 'number');
@@ -135,6 +135,24 @@ apiTest(requestMethod => {
           });
         });
       });
+
+      if(requestMethod === 'cors') {
+        describe('when given an invalid json response', function () {
+          let example = merge(clone(valid), {
+            number: '5454545454545454'
+          });
+
+          it('produces an api-error with the raw responseText', function (done) {
+            this.recurly.token(builder(example), (err, token) => {
+              console.log(token, err);
+              assert(!token);
+              assert(err.code === 'api-error');
+              assert(err.message.indexOf('problem parsing the API response with: some json that cannot be parsed'));
+              done();
+            });
+          });
+        });
+      }
 
       describe('when given an invalid cvv', function () {
         let example = merge(clone(valid), { cvv: 'blah' });


### PR DESCRIPTION
We've seen some errors where the Recurly API must have responded with invalid JSON, but we haven't been able to see it live in order to see what the responseText actually is, so it'd would be helpful to include that in the error message.