### PR TITLE
Also send name, address, etc fields for apple pay token creation

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -1,7 +1,9 @@
 import Promise from 'promise';
 import Emitter from 'component-emitter';
 import errors from '../errors';
+import dom from '../util/dom';
 import {Pricing} from './pricing';
+import {normalize} from '../util/normalize';
 
 const debug = require('debug')('recurly:apple-pay');
 
@@ -17,6 +19,28 @@ const APPLE_PAY_API_VERSION = 2;
 export function factory (options) {
   return new ApplePay(Object.assign({}, options, { recurly: this }));
 };
+
+/**
+ * Fields that are sent to API.
+ *
+ * @type {Array}
+ * @private
+ */
+
+var fields = [
+  'first_name',
+  'last_name',
+  'address1',
+  'address2',
+  'country',
+  'city',
+  'state',
+  'postal_code',
+  'phone',
+  'vat_number',
+  'fraud_session_id',
+  'token'
+];
 
 /**
  * Initializes an Apple Pay session.
@@ -238,7 +262,17 @@ class ApplePay extends Emitter {
   onPaymentAuthorized (event) {
     debug('Payment authorization received', event);
 
-    this.recurly.request('post', '/apple_pay/token', event.payment.token, (err, token) => {
+    // TODO: can we be sure an apple pay form will always have the number field?
+    // var selector = this.recurlyconfig.fields.number.selector;
+    var selector = '[data-recurly=first_name]'
+    var form = dom.findNodeInParents(window.document.querySelector(selector), 'form');
+    var data = normalize(fields, form);
+    var inputs = data.values || {};
+
+    inputs['paymentData'] = event.payment.token['paymentData']
+    inputs['paymentMethod'] = event.payment.token['paymentMethod']
+
+    this.recurly.request('post', '/apple_pay/token', inputs, (err, token) => {
       if (err) {
         this.session.completePayment(this.session.STATUS_FAILURE);
         return this.error('apple-pay-payment-failure', err);


### PR DESCRIPTION
When sending Apple Pay payment data for a token, include the name and address fields. These are required to later build a valid billing info so that the customer can be billed successfully.


cc: @chrissrogers 