### PR TITLE
Makes origin checking compatible with IE11 + possibly others

### DIFF
--- a/lib/recurly/relay.js
+++ b/lib/recurly/relay.js
@@ -28,8 +28,17 @@ function relay (done) {
   self.origin = function () {
     var parser = document.createElement('a');
     parser.href = self.config.api;
-
-    return parser.origin;
+    
+    if (parser.origin) {
+      return parser.origin;
+    }
+    
+    // IE11 seems to append :443 to parser.host even when it's not there
+    if (parser.protocol === 'https:' && parser.port == 443) {
+      return parser.protocol+'//'+parser.hostname;
+    }
+    
+    return parser.protocol+'//'+parser.host;
   };
 
   events.bind(window, 'message', function listener (event) {


### PR DESCRIPTION
The `origin` attribute isn't available in IE11 on Windows 7, I haven't checked other IE versions, but I suspect the same. 

If anyone has access to multiple versions, they can check with this. https://jsfiddle.net/oLtyn55q/6/

The patch should at least make things work for more browsers than the current implementation does.