### PR TITLE
Fixes issue with new PayPal API usage of deprecated method

### DIFF
--- a/lib/recurly/paypal/index.js
+++ b/lib/recurly/paypal/index.js
@@ -67,7 +67,7 @@ export class PayPal extends Emitter {
    * Pass-through for now to deprecated paypal opener method
    */
   start (data) {
-    deprecatedPaypal.apply(this.recurly, data, (err, token) => {
+    deprecatedPaypal.call(this.recurly, data, (err, token) => {
       if (err) this.error('paypal-tokenize-error', { err });
       else this.emit('token', token);
     });


### PR DESCRIPTION
- Callbacks were improperly registered with the deprecated PayPal invocation