### PR TITLE
Adds a missing error type

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -259,3 +259,7 @@ errors.add('paypal-braintree-api-error', {
 errors.add('paypal-braintree-tokenize-braintree-error', {
   message: 'An error occurred while attempting to generate the Braintree token'
 });
+
+errors.add('paypal-braintree-tokenize-recurly-error', {
+  message: 'An error occurred while attempting to generate the Braintree token within Recurly'
+});

--- a/lib/recurly/paypal/strategy/braintree.js
+++ b/lib/recurly/paypal/strategy/braintree.js
@@ -70,7 +70,7 @@ export class BraintreeStrategy extends PayPalStrategy {
         debug('Device data collector created');
         this.deviceFingerprint = collector.deviceData;
         braintree.paypal.create({ client }, (error, paypal) => {
-          if (error) return this.fail('paypal-braintree-api-error', { error });
+          if (error) return this.fail('paypal-braintree-api-error', { cause: error });
           debug('PayPal client created');
           this.paypal = paypal;
           this.emit('ready');
@@ -86,7 +86,7 @@ export class BraintreeStrategy extends PayPalStrategy {
     this.paypal.tokenize(tokenOpts, (error, payload) => {
       if (error) {
         if (error.code === 'PAYPAL_POPUP_CLOSED') return this.emit('cancel');
-        return this.error('paypal-braintree-tokenize-braintree-error', { error });
+        return this.error('paypal-braintree-tokenize-braintree-error', { cause: error });
       }
 
       debug('Token payload received', payload);
@@ -97,7 +97,7 @@ export class BraintreeStrategy extends PayPalStrategy {
 
       // Tokenize with Recurly
       this.recurly.request('post', '/paypal/token', { type: 'braintree', payload }, (error, token) => {
-        if (error) return this.error('paypal-braintree-tokenize-recurly-error', { error });
+        if (error) return this.error('paypal-braintree-tokenize-recurly-error', { cause: error });
         this.emit('token', token);
       });
     });


### PR DESCRIPTION
- For when Braintree is misconfigured within Recurly [here](https://github.com/recurly/recurly-js/blob/master/lib/recurly/paypal/strategy/braintree.js#L100)

cc @karentobo 