### PR TITLE
use Apple Pay contact data when form name and address are not supplied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@ env:
     - BROWSER=safari
     - BROWSER=ie_10
     - BROWSER=ie_11
-    - BROWSER=opera
     - BROWSER=ios_9_3
     - BROWSER=android

--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -31,10 +31,6 @@ var sauceBrowsers = {
     platform: 'Windows 7',
     version: '11'
   },
-  sl_opera: {
-    base: 'SauceLabs',
-    browserName: 'opera'
-  },
   sl_ios_9_3: {
     base: 'SauceLabs',
     browserName: 'iphone',

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -180,9 +180,10 @@ class ApplePay extends Emitter {
     inputs.paymentMethod = data.token.paymentMethod;
 
     if (!data.billingContact) return;
+    if (FIELDS.some(field => inputs[field])) return;
 
     FIELDS.forEach(field => {
-      if (inputs[field] || !APPLE_PAY_ADDRESS_MAP[field]) return;
+      if (!APPLE_PAY_ADDRESS_MAP[field]) return;
 
       let tokenData = data.billingContact[APPLE_PAY_ADDRESS_MAP[field]];
 

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -8,6 +8,16 @@ const debug = require('debug')('recurly:apple-pay');
 
 const SESSION_TIMEOUT = 300000; // 5m
 const APPLE_PAY_API_VERSION = 2;
+const APPLE_PAY_ADDRESS_MAP = {
+  first_name: 'givenName',
+  last_name: 'familyName',
+  address1: 'addressLines',
+  address2: 'addressLines',
+  city: 'locality',
+  state: 'administrativeArea',
+  postal_code: 'postalCode',
+  country: 'countryCode'
+}
 
 /**
  * Instantiation factory
@@ -61,6 +71,7 @@ class ApplePay extends Emitter {
       currencyCode: this.config.currency,
       supportedNetworks: this.config.supportedNetworks,
       merchantCapabilities: this.config.merchantCapabilities,
+      requiredBillingContactFields: ['postalAddress'],
       total: { label: this.config.label, amount: this.config.total }
     });
 
@@ -159,6 +170,31 @@ class ApplePay extends Emitter {
   }
 
   /**
+   * Maps data from the Apple Pay token into the inputs
+   * object that is sent to RA for tokenization
+   *
+   * @public
+   */
+  mapPaymentData (inputs, data) {
+    inputs.paymentData = data.token.paymentData;
+    inputs.paymentMethod = data.token.paymentMethod;
+
+    if (!data.billingContact) return;
+
+    FIELDS.forEach(field => {
+      if (inputs[field] || !APPLE_PAY_ADDRESS_MAP[field]) return;
+
+      let tokenData = data.billingContact[APPLE_PAY_ADDRESS_MAP[field]];
+
+      // address lines are an array from Apple Pay
+      if (field === 'address1') tokenData = tokenData[0];
+      else if (field === 'address2') tokenData = tokenData[1];
+
+      inputs[field] = tokenData;
+    });
+  }
+
+  /**
    * Begins Apple Pay transaction
    *
    * @public
@@ -247,8 +283,7 @@ class ApplePay extends Emitter {
     var data = normalize(FIELDS, this.config.form, { parseCard: false });
     var inputs = data.values || {};
 
-    inputs['paymentData'] = event.payment.token['paymentData']
-    inputs['paymentMethod'] = event.payment.token['paymentMethod']
+    this.mapPaymentData(inputs, event.payment);
 
     this.recurly.request('post', '/apple_pay/token', inputs, (err, token) => {
       if (err) {

--- a/test/apple-pay.test.js
+++ b/test/apple-pay.test.js
@@ -224,6 +224,61 @@ apiTest(function (requestMethod) {
       });
     });
 
+    describe('mapPaymentData', function () {
+      let applePayData = {
+        token: {
+          paymentData: 'apple pay token',
+          paymentMethod: 'card info'
+        },
+        billingContact: {
+          givenName: 'Emmet',
+          familyName: 'Brown',
+          addressLines: ['1640 Riverside Drive', 'Suite 1'],
+          locality: 'Hill Valley',
+          administrativeArea: 'CA',
+          postalCode: '91103',
+          countryCode: 'us'
+        }
+      };
+      let inputs = {};
+
+      it('maps the apple pay token and address info into the inputs', function () {
+        let applePay = this.recurly.ApplePay();
+        let data = clone(applePayData);
+        applePay.mapPaymentData(inputs, data);
+        assert.equal('apple pay token', inputs.paymentData);
+        assert.equal('card info', inputs.paymentMethod);
+        assert.equal('Emmet', inputs.first_name);
+        assert.equal('Brown', inputs.last_name);
+        assert.equal('1640 Riverside Drive', inputs.address1);
+        assert.equal('Suite 1', inputs.address2);
+        assert.equal('Hill Valley', inputs.city);
+        assert.equal('CA', inputs.state);
+        assert.equal('91103', inputs.postal_code);
+        assert.equal('us', inputs.country);
+      });
+
+      it('prioritizes existing input data from the payment form', function () {
+        let applePay = this.recurly.ApplePay();
+        let data = clone(applePayData);
+        let inputs = {
+          first_name: 'Marty',
+          last_name: 'McFly'
+        };
+        applePay.mapPaymentData(inputs, data);
+        assert.equal('apple pay token', inputs.paymentData);
+        assert.equal('card info', inputs.paymentMethod);
+        assert.equal('Marty', inputs.first_name);
+        assert.equal('McFly', inputs.last_name);
+        assert.equal('1640 Riverside Drive', inputs.address1);
+        assert.equal('Suite 1', inputs.address2);
+        assert.equal('Hill Valley', inputs.city);
+        assert.equal('CA', inputs.state);
+        assert.equal('91103', inputs.postal_code);
+        assert.equal('us', inputs.country);
+      });
+    });
+
     describe('internal event handlers', function () {
       beforeEach(function (done) {
         this.applePay = this.recurly.ApplePay(validOpts);

--- a/test/apple-pay.test.js
+++ b/test/apple-pay.test.js
@@ -240,11 +240,21 @@ apiTest(function (requestMethod) {
           countryCode: 'us'
         }
       };
-      let inputs = {};
+      let inputsDefault = {
+        first_name: '',
+        last_name: '',
+        address1: '',
+        address2: '',
+        city: '',
+        state: '',
+        postal_code: '',
+        country: ''
+      };
 
       it('maps the apple pay token and address info into the inputs', function () {
         let applePay = this.recurly.ApplePay();
         let data = clone(applePayData);
+        let inputs = clone(inputsDefault);
         applePay.mapPaymentData(inputs, data);
         assert.equal('apple pay token', inputs.paymentData);
         assert.equal('card info', inputs.paymentMethod);
@@ -261,21 +271,20 @@ apiTest(function (requestMethod) {
       it('prioritizes existing input data from the payment form', function () {
         let applePay = this.recurly.ApplePay();
         let data = clone(applePayData);
-        let inputs = {
-          first_name: 'Marty',
-          last_name: 'McFly'
-        };
+        let inputs = clone(inputsDefault);
+        inputs.first_name = 'Marty';
+        inputs.last_name = 'McFly';
         applePay.mapPaymentData(inputs, data);
         assert.equal('apple pay token', inputs.paymentData);
         assert.equal('card info', inputs.paymentMethod);
         assert.equal('Marty', inputs.first_name);
         assert.equal('McFly', inputs.last_name);
-        assert.equal('1640 Riverside Drive', inputs.address1);
-        assert.equal('Suite 1', inputs.address2);
-        assert.equal('Hill Valley', inputs.city);
-        assert.equal('CA', inputs.state);
-        assert.equal('91103', inputs.postal_code);
-        assert.equal('us', inputs.country);
+        assert.equal('', inputs.address1);
+        assert.equal('', inputs.address2);
+        assert.equal('', inputs.city);
+        assert.equal('', inputs.state);
+        assert.equal('', inputs.postal_code);
+        assert.equal('', inputs.country);
       });
     });
 


### PR DESCRIPTION
If the merchant doesn't supply a form for the user to specify name and address data, attempt to use data present in Apple Pay contact data.

**Testing notes**
- [ ] When form fields are present, they are given priority and Apple Pay address is ignored.
- [ ] When Apple Pay card is displayed in Safari, it now asks for the address to use with the payment
- [ ] For fields not specified in purchase form, the address data specified in the Apple Pay popup card is used and passed.