### PR TITLE
Don’t require form for Apple Pay

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -129,11 +129,10 @@ class ApplePay extends Emitter {
    * @private
    */
   configure (options) {
-    if ('form' in options) this.config.form = options.form;
-    else return this.initError = this.error('apple-pay-config-missing', { opt: 'form' });
-
     if ('label' in options) this.config.label = options.label;
     else return this.initError = this.error('apple-pay-config-missing', { opt: 'label' });
+
+    if ('form' in options) this.config.form = options.form;
 
     // Initialize with no line items
     this.config.lineItems = [];
@@ -281,8 +280,11 @@ class ApplePay extends Emitter {
   onPaymentAuthorized (event) {
     debug('Payment authorization received', event);
 
-    var data = normalize(FIELDS, this.config.form, { parseCard: false });
-    var inputs = data.values || {};
+    let inputs = {};
+
+    if (this.config.form) {
+      inputs = normalize(FIELDS, this.config.form, { parseCard: false }).values;
+    }
 
     this.mapPaymentData(inputs, event.payment);
 

--- a/test/apple-pay.test.js
+++ b/test/apple-pay.test.js
@@ -92,11 +92,6 @@ apiTest(function (requestMethod) {
         });
       });
 
-      it('requires options.form', function () {
-        let applePay = this.recurly.ApplePay(omit(validOpts, 'form'));
-        assertInitError(applePay, 'apple-pay-config-missing', { opt: 'form' });
-      });
-
       it('requires options.label', function () {
         let applePay = this.recurly.ApplePay(omit(validOpts, 'label'));
         assertInitError(applePay, 'apple-pay-config-missing', { opt: 'label' });
@@ -203,6 +198,12 @@ apiTest(function (requestMethod) {
 
       it('establishes a session and initiates it', function () {
         let applePay = this.recurly.ApplePay(validOpts);
+        applePay.begin();
+        assert(applePay.session instanceof ApplePaySessionStub);
+      });
+
+      it('establishes a session and initiates it without options.form', function () {
+        let applePay = this.recurly.ApplePay(omit(validOpts, 'form'));
         applePay.begin();
         assert(applePay.session instanceof ApplePaySessionStub);
       });


### PR DESCRIPTION
We recently added the ability to use the Apple Pay contact data for name/address but the code still has a validation for passing in a form, which isn't required now. This update removes that requirement.