### PR TITLE
Fixes iOS 11 CI errors

### DIFF
--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -88,8 +88,11 @@ export class Bus extends Emitter {
 
     this.debug(`sending message to ${this.recipients.length} recipients`, message);
     this.recipients.forEach(r => {
-      if (r.postMessage) r.postMessage(message, '*');
-      else if (typeof r.emit === 'function') r.emit(message.event, message.body);
+      if (r.postMessage) {
+        (typeof r.postMessage === 'function') && r.postMessage(message, '*');
+      } else if (typeof r.emit === 'function') {
+        r.emit(message.event, message.body);
+      }
     });
   }
 


### PR DESCRIPTION
- iOS 11 CI tests have not proven reliable
- Field window.postMessage is not always available. This attempts to resolve the issue by adding additional call checks.
- Example: https://travis-ci.org/recurly/recurly-js/jobs/296127480