### PR TITLE
CheckoutPricing: Taxes and Adjustment Currencies

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -176,7 +176,7 @@ errors.add('invalid-addon', {
 });
 
 errors.add('invalid-currency', {
-  message: c => `The given currency (${c.code}) is not among the valid codes for the specified plan(s): ${c.allowed}.`
+  message: c => `The given currency (${c.currency}) is not among the valid codes for the specified plan(s): ${c.allowed}.`
 });
 
 errors.add('invalid-subscription-currency', {

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -12,6 +12,7 @@ import version from './version';
 import bankAccount from './recurly/bank-account';
 import coupon from './recurly/coupon';
 import giftcard from './recurly/giftcard';
+import tax from './recurly/tax';
 import {token} from './recurly/token';
 import {factory as Frame} from './recurly/frame';
 import {factory as ApplePay} from './recurly/apple-pay';
@@ -279,6 +280,20 @@ export class Recurly extends Emitter {
   }
 
   /**
+   * Performs a request with caching
+   */
+
+  cachedRequest (method, route, data, done) {
+    let cache = this._cachedRequests = this._cachedRequests || {};
+    const slug = [method, route, JSON.stringify(data)].join('-');
+    if (cache[slug]) done(null, ...cache[slug]);
+    else this.request(method, route, data, (err, ...args) => {
+      if (!err) cache[slug] = args;
+      done(err, ...args);
+    });
+  }
+
+  /**
    * Pipelines a request across several requests
    *
    * Chunks are made of `data[by]`` in `size`. If any request errors,
@@ -440,7 +455,7 @@ Recurly.prototype.ApplePay = ApplePay;
 Recurly.prototype.PayPal = PayPal;
 Recurly.prototype.paypal = deprecatedPaypal;
 Recurly.prototype.plan = require('./recurly/plan');
-Recurly.prototype.tax = require('./recurly/tax');
+Recurly.prototype.tax = tax;
 Recurly.prototype.token = token;
 Recurly.prototype.validate = require('./recurly/validate');
 

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -78,8 +78,6 @@ export default class Calculations {
     this.items = pricing.items;
     this._itemizedSets = { now: {}, next: {} };
 
-    this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
-
     this.price = {
       now: { items: [] },
       next: { items: [] },
@@ -255,7 +253,8 @@ export default class Calculations {
     // Taxation requires that we at least have base tax information
     if (isEmpty(baseTaxInfo)) return Promise.resolve();
 
-    const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
+    const getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
+    const getTaxesFor = item => getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
     const fixedAmount = amt => parseFloat(amt.toFixed(6));
     let taxRates = [];
 
@@ -265,7 +264,7 @@ export default class Calculations {
         taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
       });
     }))
-    .then(Promise.all(this.taxableSubscriptions.map(sub => {
+    .then(() => Promise.all(this.taxableSubscriptions.map(sub => {
       return getTaxesFor(sub).then(taxes => {
         taxRates = taxRates.concat(taxes);
         taxes.forEach(tax => {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -79,7 +79,6 @@ export default class Calculations {
 
     this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
 
-    // FIXME: set this structure functionally?
     this.price = {
       now: { items: [] },
       next: { items: [] },
@@ -108,7 +107,9 @@ export default class Calculations {
       .done(() => {
         each(this.price.now, decimalizeMember, this.price.now);
         each(this.price.next, decimalizeMember, this.price.next);
-        done(this.price)
+        this.price.now.items.forEach(item => each(item, decimalizeMember, item));
+        this.price.next.items.forEach(item => each(item, decimalizeMember, item));
+        done(this.price);
       });
   }
 

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -255,14 +255,17 @@ export default class Calculations {
 
     const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
     const fixedAmount = amt => parseFloat(amt.toFixed(6));
+    let taxRates = [];
 
     return Promise.all(this.taxableAdjustments.map(adj => {
       return getTaxesFor(adj).then(taxes => {
+        taxRates = taxRates.concat(taxes);
         taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
       });
     }))
     .then(Promise.all(this.taxableSubscriptions.map(sub => {
       return getTaxesFor(sub).then(taxes => {
+        taxRates = taxRates.concat(taxes);
         taxes.forEach(tax => {
           taxNow += fixedAmount(sub.price.now.subtotal * tax.rate);
           taxNext += fixedAmount(sub.price.next.subtotal * tax.rate);
@@ -271,6 +274,7 @@ export default class Calculations {
     })))
     .catch(err => this.pricing.emit('error', err))
     .then(() => {
+      this.price.taxes = uniq(taxRates);
       this.price.now.taxes = taxCeil(taxNow);
       this.price.next.taxes = taxCeil(taxNext);
     });

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -173,7 +173,7 @@ export default class Calculations {
     this.price.next.adjustments = 0; // always zero
     this._itemizedSets.now.adjustments = [];
 
-    this.items.adjustments.forEach(adjustment => {
+    this.validAdjustments.forEach(adjustment => {
       const { amount: unitAmount, quantity, code } = adjustment;
       const amount = unitAmount * quantity;
       const item = { type: 'adjustment', code, amount, quantity, unitAmount };

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash.isempty';
 import orderBy from 'lodash.orderby';
 import Promise from 'promise';
 import uniq from 'lodash.uniq';
+import uniqBy from 'lodash.uniqby';
 import decimalizeMember from '../../../util/decimalize-member';
 import taxCeil from '../../../util/tax-ceil';
 
@@ -275,7 +276,7 @@ export default class Calculations {
     })))
     .catch(err => this.pricing.emit('error', err))
     .then(() => {
-      this.price.taxes = uniq(taxRates);
+      this.price.taxes = uniqBy(taxRates, JSON.stringify);
       this.price.now.taxes = taxCeil(taxNow);
       this.price.next.taxes = taxCeil(taxNext);
     });
@@ -304,7 +305,7 @@ export default class Calculations {
       let used = 0;
       let remains = 0;
 
-      if (giftCardValue > price){
+      if (giftCardValue > price) {
         used = price;
         remains = giftCardValue - price;
       } else {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -113,11 +113,11 @@ export default class Calculations {
   }
 
   get validAdjustments () {
-    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+    return this.pricing.validAdjustments;
   }
 
   get validSubscriptions () {
-    return this.items.subscriptions.filter(sub => sub.isValid);
+    return this.pricing.validSubscriptions;
   }
 
   get hasValidSubscriptions () {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -1,9 +1,12 @@
 import currencySymbolFor from 'currency-symbol-map';
 import each from 'component-each';
 import groupBy from 'lodash.groupby';
+import isEmpty from 'lodash.isempty';
 import orderBy from 'lodash.orderby';
 import Promise from 'promise';
+import uniq from 'lodash.uniq';
 import decimalizeMember from '../../../util/decimalize-member';
+import taxCeil from '../../../util/tax-ceil';
 
 // Price structure
 //
@@ -74,6 +77,8 @@ export default class Calculations {
     this.items = pricing.items;
     this._itemizedSets = { now: {}, next: {} };
 
+    this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
+
     // FIXME: set this structure functionally?
     this.price = {
       now: { items: [] },
@@ -86,7 +91,7 @@ export default class Calculations {
         code: this.items.currency,
         symbol: currencySymbolFor(this.items.currency)
       },
-      // taxes: []
+      taxes: []
     };
 
     // TODO: Instead of relying on ordering assumptions, it would be ideal to define each
@@ -107,12 +112,30 @@ export default class Calculations {
       });
   }
 
+  get validAdjustments () {
+    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+  }
+
   get validSubscriptions () {
     return this.items.subscriptions.filter(sub => sub.isValid);
   }
 
   get hasValidSubscriptions () {
     return this.validSubscriptions.length > 0;
+  }
+
+  get taxableAdjustments () {
+    return this.validAdjustments.filter(adj => !adj.taxExempt);
+  }
+
+  get taxableSubscriptions () {
+    return this.validSubscriptions.filter(sub => !sub.items.plan.tax_exempt);
+  }
+
+  // includes undefined entries
+  get taxCodes () {
+    const taxableItems = this.taxableAdjustments.concat(this.taxableSubscriptions);
+    return uniq(taxableItems.map(item => item.taxCode));
   }
 
   /**
@@ -183,13 +206,13 @@ export default class Calculations {
     if (!coupon) return promise;
 
     if (coupon.discount.rate) {
-      const {discountableNow, discountableNext} = this.discountableSubtotals(coupon, { setupFees: false });
+      const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
       this.price.now.discount = round(discountableNow * coupon.discount.rate);
       this.price.next.discount = round(discountableNext * coupon.discount.rate);
     } else if (coupon.discount.type === 'free_trial') {
       promise = promise.then(() => this.applyFreeTrialCoupon());
     } else {
-      const {discountableNow, discountableNext} = this.discountableSubtotals(coupon);
+      const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
       this.price.now.discount = Math.min(discountableNow, coupon.discount.amount[this.items.currency]);
       this.price.next.discount = Math.min(discountableNext, coupon.discount.amount[this.items.currency]);
     }
@@ -205,7 +228,7 @@ export default class Calculations {
    * @return {Promise}
    */
   subtotals () {
-    const {now, next} = this.price;
+    const { now, next } = this.price;
     this.price.now.subtotal = now.subscriptions + now.adjustments - now.discount;
     this.price.next.subtotal = next.subscriptions - next.discount;
     return Promise.resolve();
@@ -214,12 +237,43 @@ export default class Calculations {
   /**
    * Taxes
    *
+   * Workflow
+   * - collects tax rates for each tax code and the
+   *   base tax info (country, postal code, vat number)
+   * - applies taxes to each taxable item, according to its tax code
+   *
    * @return {Promise}
    */
   taxes () {
-    this.price.now.taxes = 0;
-    this.price.next.taxes = 0;
-    return Promise.resolve();
+    let taxNow = this.price.now.taxes = 0;
+    let taxNext = this.price.next.taxes = 0;
+
+    const baseTaxInfo = Object.assign({}, this.items.address, this.items.tax);
+
+    // Taxation requires that we at least have base tax information
+    if (isEmpty(baseTaxInfo)) return Promise.resolve();
+
+    const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
+    const fixedAmount = amt => parseFloat(amt.toFixed(6));
+
+    return Promise.all(this.taxableAdjustments.map(adj => {
+      return getTaxesFor(adj).then(taxes => {
+        taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
+      });
+    }))
+    .then(Promise.all(this.taxableSubscriptions.map(sub => {
+      return getTaxesFor(sub).then(taxes => {
+        taxes.forEach(tax => {
+          taxNow += fixedAmount(sub.price.now.subtotal * tax.rate);
+          taxNext += fixedAmount(sub.price.next.subtotal * tax.rate);
+        });
+      });
+    })))
+    .catch(err => this.pricing.emit('error', err))
+    .then(() => {
+      this.price.now.taxes = taxCeil(taxNow);
+      this.price.next.taxes = taxCeil(taxNext);
+    });
   }
 
   /**

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -43,6 +43,14 @@ export default class CheckoutPricing extends Pricing {
     return Calculations;
   }
 
+  get validAdjustments () {
+    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+  }
+
+  get validSubscriptions () {
+    return this.items.subscriptions.filter(sub => sub.isValid);
+  }
+
   // Currency codes common to all subscriptions
   get subscriptionCurrencies () {
     return intersection(...this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
@@ -82,9 +90,15 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
-      debug('set.currency');
-      this.emit('set.currency', code);
-      resolve(code);
+      // Propagate currency changes to each subscription
+      Promise.all(this.validSubscriptions.map(sub => sub.currency(code).reprice()))
+        // Eject gift cards on currency change
+        .then(() => this.giftCard(null))
+        .then(() => {
+          debug('set.currency');
+          this.emit('set.currency', code);
+          resolve(code);
+        });
     }, this);
   }
 

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -82,10 +82,6 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
-      // FIXME: Need to propagate currency changes to each subscription
-      // FIXME: Need to swap out adjustments based on currency
-      // FIXME: eject gift cards on currency change
-
       debug('set.currency');
       this.emit('set.currency', code);
       resolve(code);

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -257,9 +257,8 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} address
    * @param {String} address.country
-   * @param {String|Number} address.postalCode
+   * @param {String} address.postalCode
    * @param {String} address.vatNumber
-   * @param {Function} [done] callback
    * @return {PricingPromise}
    * @public
    */
@@ -272,7 +271,6 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} tax
    * @param {String} tax.vatNumber
-   * @param {Function} [done] callback
    * @public
    */
   tax (tax) {

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -45,7 +45,7 @@ export default class CheckoutPricing extends Pricing {
 
   // Currency codes common to all subscriptions
   get subscriptionCurrencies () {
-    return intersection(this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
+    return intersection(...this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
   }
 
   // Plan codes of all subscriptions

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -271,7 +271,6 @@ export default class CheckoutPricing extends Pricing {
    * Updates tax info
    *
    * @param {Object} tax
-   * @param {String} tax.taxCode
    * @param {String} tax.vatNumber
    * @param {Function} [done] callback
    * @public

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -165,12 +165,13 @@ export default class CheckoutPricing extends Pricing {
    * @param {Number}  adjustment.amount in unit price (1.0 for USD, etc)
    * @param {Number}  [adjustment.quantity=1] number of units
    * @param {String}  [adjustment.code=uuid()] unique identifier
+   * @param {String}  [adjustment.currency=this.items.currency] currency code
    * @param {Boolean} [adjustment.taxExempt=false] whether this adjustment is tax exempt
    * @param {String}  [adjustment.taxCode] taxation code
    * @return {PricingPromise}
    * @public
    */
-  adjustment ({amount, quantity = 1, code = uuid(), taxExempt = false, taxCode}) {
+  adjustment ({ amount, quantity = 1, code = uuid(), currency = this.items.currency, taxExempt = false, taxCode }) {
     return new PricingPromise((resolve, reject) => {
       amount = Number(amount);
       if (!isFinite(amount)) {
@@ -186,8 +187,7 @@ export default class CheckoutPricing extends Pricing {
       quantity = parseInt(quantity, 10);
       taxExempt = !!taxExempt;
 
-      let adjustment = { amount, quantity, code, taxExempt };
-      if (taxCode) adjustment.taxCode = taxCode;
+      const adjustment = { amount, quantity, code, currency, taxExempt, taxCode };
 
       this.items.adjustments.push(adjustment);
 
@@ -243,13 +243,13 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} address
    * @param {String} address.country
-   * @param {String|Number} address.postal_code
-   * @param {String} address.vat_number
+   * @param {String|Number} address.postalCode
+   * @param {String} address.vatNumber
    * @param {Function} [done] callback
    * @return {PricingPromise}
    * @public
    */
-  address (address, done) {
+  address (address) {
     return new PricingPromise(this.itemUpdateFactory('address', address), this);
   }
 

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -137,7 +137,7 @@ export default class CheckoutPricing extends Pricing {
         }
       }
 
-      if (this.items.currency) this.currency(subscription.items.currency);
+      if (!this.items.currency) this.currency(subscription.items.currency);
 
       const addSubscription = () => {
         subscription.on('change:external', () => this.reprice());

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -1,6 +1,7 @@
 import intersection from 'lodash.intersection';
 import isEmpty from 'lodash.isempty';
 import isFinite from 'lodash.isfinite';
+import Promise from 'promise';
 import uniq from 'lodash.uniq';
 import errors from '../../../errors';
 import uuid from '../../../util/uuid';
@@ -83,7 +84,7 @@ export default class CheckoutPricing extends Pricing {
       if (!this.subscriptionsAllowCurrency(code)) {
         // TODO: Check the semantics of this error. Probably needs to be updated for CheckoutPricing
         return this.error(errors('invalid-currency', {
-          code,
+          currency: code,
           allowed: this.subscriptionCurrencies
         }), reject, 'currency');
       }

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -82,6 +82,10 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
+      // FIXME: Need to propagate currency changes to each subscription
+      // FIXME: Need to swap out adjustments based on currency
+      // FIXME: eject gift cards on currency change
+
       debug('set.currency');
       this.emit('set.currency', code);
       resolve(code);
@@ -251,6 +255,19 @@ export default class CheckoutPricing extends Pricing {
    */
   address (address) {
     return new PricingPromise(this.itemUpdateFactory('address', address), this);
+  }
+
+  /**
+   * Updates tax info
+   *
+   * @param {Object} tax
+   * @param {String} tax.taxCode
+   * @param {String} tax.vatNumber
+   * @param {Function} [done] callback
+   * @public
+   */
+  tax (tax) {
+    return new PricingPromise(this.itemUpdateFactory('tax', tax), this);
   }
 
   /**

--- a/lib/recurly/pricing/promise.js
+++ b/lib/recurly/pricing/promise.js
@@ -21,6 +21,7 @@ const PRICING_METHODS = [
   'remove',
   'reprice',
   'giftcard',
+  'giftCard',
   'shippingAddress',
   'subscription',
   'adjustment'

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -2,7 +2,7 @@ import errors from '../../../errors';
 import PricingPromise from '../promise';
 import SubscriptionPricing from './';
 
-const DISABLED_METHODS = [
+export const DISABLED_METHODS = [
   'address',
   'coupon',
   'currency',
@@ -10,7 +10,7 @@ const DISABLED_METHODS = [
   'shippingAddress'
 ];
 
-const DEFERRED_METHODS = [
+export const DEFERRED_METHODS = [
   'couponIsValidForSubscription'
 ];
 

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -3,9 +3,10 @@ import PricingPromise from '../promise';
 import SubscriptionPricing from './';
 
 const DISABLED_METHODS = [
-  'coupon',
-  'giftcard',
   'address',
+  'coupon',
+  'currency',
+  'giftcard',
   'shippingAddress'
 ];
 
@@ -49,6 +50,10 @@ export default class EmbeddedSubscriptionPricing {
 
   get price () {
     return this.subscription.price;
+  }
+
+  get taxCode () {
+    return this.subscription.taxCode;
   }
 }
 

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -43,6 +43,11 @@ export default class SubscriptionPricing extends Pricing {
     return this.items.plan && this.price;
   }
 
+  get taxCode () {
+    if (!this.items.tax) return;
+    return this.items.tax.tax_code;
+  }
+
   reset () {
     super.reset();
     this.items.addons = [];

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -45,7 +45,7 @@ export default class SubscriptionPricing extends Pricing {
 
   get taxCode () {
     if (!this.items.tax) return;
-    return this.items.tax.tax_code;
+    return this.items.tax.taxCode || this.items.tax.tax_code;
   }
 
   reset () {
@@ -303,8 +303,10 @@ export default class SubscriptionPricing extends Pricing {
    * Updates tax info
    *
    * @param {Object} tax
-   * @param {String} tax.tax_code
-   * @param {String} tax.vat_number
+   * @param {String} tax.taxCode
+   * @param {String} tax.vatNmber
+   * @param {String} tax.tax_code // deprecated
+   * @param {String} tax.vat_number // deprecated
    * @param {Function} [done] callback
    * @public
    */

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -328,7 +328,7 @@ export default class SubscriptionPricing extends Pricing {
       if (currency === code) return resolve(currency);
       if (plan && !(code in plan.price)) {
         return self.error(errors('invalid-currency', {
-          code,
+          currency: code,
           allowed: Object.keys(plan.price)
         }), reject, 'currency');
       }

--- a/lib/recurly/tax.js
+++ b/lib/recurly/tax.js
@@ -1,11 +1,7 @@
-var clone = require('component-clone');
-
-module.exports = tax;
-
 /**
- * Tax mixin.
+ * Tax getter
  *
- * Provides a tax estimate for the given address.
+ * Provides a tax estimate for the given tax info.
  *
  * @param {Object} options
  * @param {Object} options.postal_code
@@ -15,16 +11,17 @@ module.exports = tax;
  * @param {Function} callback
  */
 
-function tax (options, callback) {
-  var request = clone(options);
+export default function tax (options, done) {
+  options = Object.assign({}, options);
 
-  if (typeof callback !== 'function') {
+  if (typeof done !== 'function') {
     throw new Error('Missing callback');
   }
 
-  if (!('currency' in request)) {
-    request.currency = this.config.currency;
-  }
-
-  this.request('get', '/tax', request, callback);
+  this.cachedRequest('get', '/tax', {
+    country: options.country,
+    postal_code: (options.postalCode || options.postal_code),
+    tax_code: (options.taxCode || options.tax_code),
+    vat_number: (options.vatNumber || options.vat_number)
+  }, done);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5442,6 +5442,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+    },
     "log-symbols": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash.partialright": "^4.2.1",
     "lodash.pick": "^4.4.0",
     "lodash.uniq": "^4.5.0",
+    "lodash.uniqby": "^4.7.0",
     "mixin": "https://github.com/kewah/mixin#0.1.0",
     "promise": "7.1.1",
     "qs": "0.6.6",

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -586,6 +586,63 @@ describe('CheckoutPricing', function () {
   });
 
   /**
+   * Currency
+   */
+
+  describe('CheckoutPricing#currency', () => {
+    it('Updates the CheckoutPricing and constituent subscription currencies', function (done) {
+      this.pricing
+        .subscription(this.subscriptionPricingExample)
+        .reprice()
+        .then(price => {
+          assert.equal(price.currency.code, 'USD');
+          assert.equal(this.subscriptionPricingExample.price.currency.code, 'USD');
+        })
+        .currency('EUR')
+        .done(price => {
+          assert.equal(price.currency.code, 'EUR');
+          assert.equal(this.subscriptionPricingExample.price.currency.code, 'EUR');
+          done();
+        });
+    });
+
+    it('throws an error when given a currency not supported by the subscriptions', function (done) {
+      this.pricing
+        .subscription(this.subscriptionPricingExample)
+        .currency('GBP')
+        .catch(err => {
+          assert.equal(err.code, 'invalid-currency');
+          assert.equal(this.pricing.price.currency.code, 'USD');
+          done();
+        })
+        .done();
+    });
+
+    it('emits set.currency if the currency changes', function () {
+      assert.equal(this.pricing.price.currency.code, 'USD');
+      this.pricing.on('set.currency', code => {
+        assert.equal(code, 'EUR');
+        assert.equal(this.pricing.price.currency.code, 'EUR');
+        done();
+      });
+      this.pricing.currency('EUR');
+    });
+
+    it('removes a gift card if the currency changes', function () {
+      this.pricing
+        .giftCard('super-gift-card')
+        .then(() => {
+          assert.equal(typeof this.pricing.giftCard, 'object');
+        })
+        .currency('EUR')
+        .done(() => {
+          assert.equal(this.pricing.giftCard, undefined);
+          done();
+        });
+    });
+  });
+
+  /**
    * Gift cards
    */
 

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -586,7 +586,7 @@ describe('CheckoutPricing', function () {
   });
 
   /**
-   * Subscriptions
+   * Gift cards
    */
 
   describe('CheckoutPricing#giftCard', () => {
@@ -669,10 +669,16 @@ describe('CheckoutPricing', function () {
   });
 
   /**
-   * address - TODO
+   * Address
    */
 
   describe('CheckoutPricing#address', () => {});
+
+  /**
+   * Taxes
+   */
+
+  describe('CheckoutPricing#tax', () => {});
 });
 
 function subscriptionPricingFactory (planCode = 'basic', recurly, done) {

--- a/test/pricing/subscription/embedded.test.js
+++ b/test/pricing/subscription/embedded.test.js
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import SubscriptionPricing from '../../../lib/recurly/pricing/subscription';
+import EmbeddedSubscriptionPricing, {DISABLED_METHODS, DEFERRED_METHODS} from '../../../lib/recurly/pricing/subscription/embedded';
+import {initRecurly} from '../../support/helpers';
+
+describe('EmbeddedSubscriptionPricing', () => {
+  beforeEach(function () {
+    this.recurly = initRecurly();
+    this.subscriptionPricingDefault = this.recurly.Pricing.Subscription();
+    this.subscriptionPricing = this.recurly.Pricing.Subscription();
+    this.embeddedSubscriptionPricing = new EmbeddedSubscriptionPricing(this.subscriptionPricing);
+  });
+
+  describe('disabling methods', () => {
+    it('Disables methods on the SubscriptionPricing instance', function () {
+      DISABLED_METHODS.forEach(method => {
+        assert.equal(this.subscriptionPricingDefault[method], SubscriptionPricing.prototype[method]);
+        assert.notEqual(this.subscriptionPricing[method], SubscriptionPricing.prototype[method]);
+      });
+    });
+
+    it('proxies the disabled methods onto the EmbeddedSubscriptionPricing instance', function () {
+      DISABLED_METHODS.forEach(method => {
+        assert.equal(this.embeddedSubscriptionPricing[method].name, SubscriptionPricing.prototype[method].name);
+      });
+    });
+  });
+
+  describe('deferred methods', () => {
+    it('calls the methods on the SubscriptionPricing instance', function () {
+      DEFERRED_METHODS.forEach(method => {
+        sinon.stub(this.subscriptionPricing, method);
+        this.embeddedSubscriptionPricing[method](1);
+        assert(this.subscriptionPricing[method].calledOnce);
+        assert(this.subscriptionPricing[method].calledWith(1));
+      });
+    });
+  });
+});

--- a/test/pricing/subscription/embedded.test.js
+++ b/test/pricing/subscription/embedded.test.js
@@ -8,6 +8,14 @@ describe('EmbeddedSubscriptionPricing', () => {
     this.recurly = initRecurly();
     this.subscriptionPricingDefault = this.recurly.Pricing.Subscription();
     this.subscriptionPricing = this.recurly.Pricing.Subscription();
+
+    // Spies
+    this.originalMethods = {};
+    DISABLED_METHODS.forEach(method => {
+      sinon.stub(this.subscriptionPricing, method);
+      this.originalMethods[method] = this.subscriptionPricing[method];
+    });
+
     this.embeddedSubscriptionPricing = new EmbeddedSubscriptionPricing(this.subscriptionPricing);
   });
 
@@ -16,12 +24,25 @@ describe('EmbeddedSubscriptionPricing', () => {
       DISABLED_METHODS.forEach(method => {
         assert.equal(this.subscriptionPricingDefault[method], SubscriptionPricing.prototype[method]);
         assert.notEqual(this.subscriptionPricing[method], SubscriptionPricing.prototype[method]);
+
+        // Calling the method does not invoke its original form
+        this.subscriptionPricing[method]();
+        assert(this.originalMethods[method].notCalled);
       });
     });
 
     it('proxies the disabled methods onto the EmbeddedSubscriptionPricing instance', function () {
       DISABLED_METHODS.forEach(method => {
-        assert.equal(this.embeddedSubscriptionPricing[method].name, SubscriptionPricing.prototype[method].name);
+        assert.equal(this.subscriptionPricingDefault[method].prototype, SubscriptionPricing.prototype[method].prototype);
+
+        // Loose assertion that this is now a bound method
+        assert.equal(typeof this.embeddedSubscriptionPricing[method], 'function');
+        assert.equal(this.embeddedSubscriptionPricing[method].prototype, undefined);
+
+        // Calling the method does invoke its original
+        assert(this.originalMethods[method].notCalled);
+        this.embeddedSubscriptionPricing[method]();
+        assert(this.originalMethods[method].calledOnce);
       });
     });
   });

--- a/test/recurly.test.js
+++ b/test/recurly.test.js
@@ -1,7 +1,9 @@
 import assert from 'assert';
+import isEmpty from 'lodash.isempty';
 import {Recurly} from '../lib/recurly';
 import CheckoutPricing from '../lib/recurly/pricing/checkout';
 import SubscriptionPricing from '../lib/recurly/pricing/subscription';
+import {initRecurly} from './support/helpers';
 
 describe('Recurly', () => {
   let recurly;
@@ -29,15 +31,7 @@ describe('Recurly', () => {
   });
 
   describe('Recurly.request', () => {
-    let cors = false;
-
-    beforeEach(() => {
-      recurly.configure({
-        publicKey: 'test',
-        api: `//${global.location.host}/api`,
-        cors: cors
-      });
-    });
+    beforeEach(() => recurly = initRecurly({ cors: false }));
 
     describe('when configured for jsonp requests', () => {
       it('invokes recurly.jsonp', () => {
@@ -48,12 +42,127 @@ describe('Recurly', () => {
     });
 
     describe('when configured for cors requests', () => {
-      before(() => cors = true);
+      beforeEach(() => recurly = initRecurly({ cors: true }));
 
       it('invokes recurly.xhr', () => {
         sinon.stub(recurly, 'xhr');
         recurly.request('get', 'test', () => {});
         assert(recurly.xhr.calledOnce);
+      });
+    });
+  });
+
+  describe('Recurly.cachedRequest', () => {
+    const noop = () => {};
+    const payload = { arbitrary: 'payload' };
+
+    beforeEach(() => recurly = initRecurly());
+
+    it('on first call, invokes recurly.request with identical parameters', () => {
+      sinon.stub(recurly, 'request');
+      recurly.cachedRequest('get', 'test', payload, noop);
+      assert(recurly.request.calledOnce);
+      assert(recurly.request.calledWith('get', 'test', payload));
+    });
+
+    it('returns and does not cache error responses', done => {
+      recurly.cachedRequest('get', 'test', payload, (err, res) => {
+        assert(err);
+        assert(isEmpty(recurly._cachedRequests));
+        done();
+      });
+    });
+
+    describe('given a successful response', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, null, { success: true });
+      });
+
+      it('returns and caches successful responses', done => {
+        recurly.cachedRequest('get', 'test', payload, (err, res) => {
+          assert.equal(err, null);
+          assert.equal(res.success, true);
+          assert.equal(Object.keys(recurly._cachedRequests).length, 1);
+          done();
+        });
+      });
+
+      it(`invokes recurly.request on the first call, and not on the
+          second, with identical responses for both requests`, done => {
+        recurly.cachedRequest('get', 'test', payload, (err, res) => {
+          assert(recurly.request.calledOnce);
+          recurly.cachedRequest('get', 'test', payload, (err, res) => {
+            assert(recurly.request.calledOnce);
+            assert.equal(Object.keys(recurly._cachedRequests).length, 1);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('Recurly.pipedRequest', () => {
+    const noop = () => {};
+    let payload = {
+      long: Array.apply(null, Array(200)).map(() => 1)
+    }
+
+    beforeEach(() => recurly = initRecurly());
+
+    describe('given all error responses', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, { code: 'not-found'}, null);
+      });
+
+      it('responds with an error', () => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .catch(err => {
+            assert.equal(err.code, 'not-found');
+            done();
+          })
+      });
+    });
+
+    describe('given successful responses', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, null, { success: true });
+      });
+
+      it('spreads a long request set across multiple requests with a default size of 100', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .done(() => {
+            assert(recurly.request.calledTwice);
+            done();
+          })
+      });
+
+      it('spreads a long request set across multiple requests with given a custom size', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long', size: 10 })
+          .done(() => {
+            assert.equal(recurly.request.callCount, 20);
+            done();
+          })
+      });
+
+      it('responds with the first response if it is an object', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .done(res => {
+            assert.equal(res.success, true);
+            done();
+          })
+      });
+
+      it('responds with a flattened response set if the responses are arrays', done => {
+        recurly.request.callsArgWith(3, null, [{ success: true }]);
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long', size: 10 })
+          .done(set => {
+            assert.equal(set.length, 20);
+            set.forEach(res => assert.equal(res.success, true));
+            done();
+          })
       });
     });
   });

--- a/test/server/fixtures/plans/basic-gbp.json
+++ b/test/server/fixtures/plans/basic-gbp.json
@@ -1,0 +1,16 @@
+{
+  "code": "basic-gbp",
+  "name": "Basic GBP",
+  "period": {
+    "interval": "months",
+    "length": 1
+  },
+  "price": {
+    "GBP": {
+      "setup_fee": 0,
+      "unit_amount": 14.0
+    }
+  },
+  "addons": [],
+  "tax_exempt": false
+}

--- a/test/server/fixtures/tax/index.js
+++ b/test/server/fixtures/tax/index.js
@@ -3,26 +3,32 @@
  * postal code to match for US sales tax
  */
 
-var USST_POSTAL_CODE = '94110';
+const USST_POSTAL_CODE = '94110';
 
 /**
  * postal code to match for US sales tax
  * with region data returned
  */
 
-var USST_POSTAL_CODE_WITH_REGION = '94129';
+const USST_POSTAL_CODE_WITH_REGION = '94129';
+
+/**
+ * tax code to match for code exception example
+ */
+
+const USST_TAX_CODE = 'valid-tax-code';
 
 /**
  * country code to match for VAT
  */
 
-var VAT_COUNTRY = 'DE';
+const VAT_COUNTRY = 'DE';
 
 /**
  * country code to match for VAT 2015
  */
 
-var VAT_2015_COUNTRY = 'GB';
+const VAT_2015_COUNTRY = 'GB';
 
 /**
  * US sales tax response
@@ -37,6 +43,7 @@ var VAT_2015_COUNTRY = 'GB';
  */
 
 module.exports = function tax () {
+  if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE && this.query.tax_code === USST_TAX_CODE) return usstWithTaxCode;
   if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE) return usst;
   if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE_WITH_REGION) return usstWithRegion;
   if (this.query.country === VAT_COUNTRY) return vat;
@@ -44,23 +51,28 @@ module.exports = function tax () {
   return none;
 };
 
-var usst = [{
+const usst = [{
   type: 'us',
   rate: '0.0875'
 }];
 
-var usstWithRegion = [{
+const usstWithRegion = [{
   type: 'us',
   rate: '0.0875',
   region: 'CA'
 }];
 
-var vat = [{
+const usstWithTaxCode = [{
+  type: 'us',
+  rate: '0.02'
+}]
+
+const vat = [{
   type: 'vat',
   rate: '0.015'
 }];
 
-var vat2015 = [{
+const vat2015 = [{
   type: 'vat',
   rate: '0.2',
   region: 'GB'


### PR DESCRIPTION
#### Description

- **To follow #391** -- includes CheckoutPricing gift card framework
- Adds `CheckoutPricing#tax`
- Adds `CheckoutPricing/Calculations#taxes` calculation routines
- Adds `CheckoutPricing#currency` change side effects
- Adds `CheckoutPricing` adjustment currency specification

#### Example - Taxes

```js
var checkoutPricing = recurly.Pricing.Checkout();

checkoutPricing
  .adjustment({ amount: 20 })
  .tax({ vatNumber: 'my-vat-number' })
  .address({
    country: 'US',
    postalCode: '94117'
  })
  .done((price) => {
    console.log(price)
  });
```

#### Example - Adjustment currency

```js
var checkoutPricing = recurly.Pricing.Checkout();

checkoutPricing.on('change', price => console.log(price));

// USD adjustment is active
checkoutPricing
  .adjustment({ amount: 20, currency: 'USD' })
  .adjustment({ amount: 15, currency: 'GBP' })
  .done();

// disables USD adjustment, activates GBP adjustment
checkoutPricing.currency('GBP').done(); 
```