### PR TITLE
CheckoutPricing: Apply Pay & PayPal support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,6 +29,10 @@ var staticConfig = {
     PhantomJSDebug: {
       base: 'PhantomJS',
       debug: true
+    },
+    ChromeDebug: {
+      base: 'Chrome',
+      flags: ['--auto-open-devtools-for-tabs']
     }
   },
   client: {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -62,7 +62,7 @@ errors.doc = function (baseURL) {
 
 errors.get = function (name, context) {
   if (!(name in errors.map)) {
-    throw new Error('invalid error');
+    throw new Error(`invalid error: ${name}`);
   } else {
     return new errors.map[name](context);
   }
@@ -177,6 +177,10 @@ errors.add('invalid-addon', {
 
 errors.add('invalid-currency', {
   message: c => `The given currency (${c.currency}) is not among the valid codes for the specified plan(s): ${c.allowed}.`
+});
+
+errors.add('invalid-plan-currency', {
+  message: c => `The requested plan (${c.planCode}) does not support the possible checkout currencies: ${c.currencies}.`
 });
 
 errors.add('invalid-subscription-currency', {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -176,7 +176,7 @@ errors.add('invalid-addon', {
 });
 
 errors.add('invalid-currency', {
-  message: c => `The given currency (${c.code}) is not among the valid codes for the specified plan(s): ${c.allowed}.`
+  message: c => `The given currency (${c.currency}) is not among the valid codes for the specified plan(s): ${c.allowed}.`
 });
 
 errors.add('invalid-subscription-currency', {

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -12,6 +12,7 @@ import version from './version';
 import bankAccount from './recurly/bank-account';
 import coupon from './recurly/coupon';
 import giftcard from './recurly/giftcard';
+import tax from './recurly/tax';
 import {token} from './recurly/token';
 import {factory as Frame} from './recurly/frame';
 import {factory as ApplePay} from './recurly/apple-pay';
@@ -279,6 +280,20 @@ export class Recurly extends Emitter {
   }
 
   /**
+   * Performs a request with caching
+   */
+
+  cachedRequest (method, route, data, done) {
+    let cache = this._cachedRequests = this._cachedRequests || {};
+    const slug = [method, route, JSON.stringify(data)].join('-');
+    if (cache[slug]) done(null, ...cache[slug]);
+    else this.request(method, route, data, (err, ...args) => {
+      if (!err) cache[slug] = args;
+      done(err, ...args);
+    });
+  }
+
+  /**
    * Pipelines a request across several requests
    *
    * Chunks are made of `data[by]`` in `size`. If any request errors,
@@ -440,7 +455,7 @@ Recurly.prototype.ApplePay = ApplePay;
 Recurly.prototype.PayPal = PayPal;
 Recurly.prototype.paypal = deprecatedPaypal;
 Recurly.prototype.plan = require('./recurly/plan');
-Recurly.prototype.tax = require('./recurly/tax');
+Recurly.prototype.tax = tax;
 Recurly.prototype.token = token;
 Recurly.prototype.validate = require('./recurly/validate');
 

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -1,7 +1,6 @@
 import Emitter from 'component-emitter';
 import errors from '../errors';
-import {CheckoutPricing} from './pricing/checkout';
-import {SubscriptionPricing} from './pricing/subscription';
+import {Pricing} from './pricing';
 import {normalize} from '../util/normalize';
 import {FIELDS} from './token';
 
@@ -102,16 +101,6 @@ class ApplePay extends Emitter {
   }
 
   /**
-   * @return {String} name for plan line item
-   * @private
-   */
-  get planLabel () {
-    // TODO: Update this to collect label from CheckoutPricing
-    if (this.config.pricing && this.config.pricing.items.plan) return this.config.pricing.items.plan.name;
-    else return 'Subscription plan';
-  }
-
-  /**
    * Initialized state callback registry
    *
    * @param  {Function} cb callback
@@ -138,11 +127,12 @@ class ApplePay extends Emitter {
     // Initialize with no line items
     this.config.lineItems = [];
 
-    // Determine pricing determination mechanism
-    if ('pricing' in options) {
-      this.config.pricing = options.pricing;
-      this.config.pricing.on('change', this.onPricingChange.bind(this));
-      this.onPricingChange(options.pricing.price);
+    // Listen for pricing changes to update totals and currency
+    const { pricing } = options
+    if (pricing instanceof Pricing) {
+      this.config.pricing = pricing;
+      pricing.on('change', price => this.updatePriceFromPricing());
+      if (pricing.hasPrice) this.updatePriceFromPricing();
     } else if ('total' in options) {
       this.config.total = options.total;
     } else {
@@ -212,12 +202,9 @@ class ApplePay extends Emitter {
    * @param  {Object} price Pricing.price
    * @private
    */
-  onPricingChange (price) {
-    // TODO: Update this to react to CheckoutPricing or SubscriptionPricing
-    if (!price) return;
-    // Reset line items
+  updatePriceFromPricing () {
     this.config.lineItems = [];
-    this.config.total = price.now.total;
+    this.config.total = this.config.pricing.totalNow;
   }
 
   /**

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -128,7 +128,7 @@ class ApplePay extends Emitter {
     this.config.lineItems = [];
 
     // Listen for pricing changes to update totals and currency
-    const { pricing } = options
+    const { pricing } = options;
     if (pricing instanceof Pricing) {
       this.config.pricing = pricing;
       pricing.on('change', price => this.updatePriceFromPricing());

--- a/lib/recurly/paypal/strategy/index.js
+++ b/lib/recurly/paypal/strategy/index.js
@@ -60,18 +60,8 @@ export class PayPalStrategy extends Emitter {
     // Bind pricing information to display options
     if (options.pricing instanceof Pricing) {
       this.pricing = options.pricing;
-
-      // Set initial price if available
-      if (this.pricing.price) {
-        this.config.display.amount = this.pricing.price.now.total;
-        this.config.display.currency = this.pricing.price.currency.code;
-      }
-
-      // React to price changes
-      this.pricing.on('change', price => {
-        this.config.display.amount = price.now.total;
-        this.config.display.currency = price.currency.code;
-      });
+      this.pricing.on('change', () => this.updatePriceFromPricing());
+      if (this.pricing.hasPrice) this.updatePriceFromPricing();
     }
   }
 
@@ -127,5 +117,15 @@ export class PayPalStrategy extends Emitter {
     let err = params[0] instanceof Error ? params[0] : errors(...params);
     this.emit('error', err);
     return err;
+  }
+
+  /**
+   * Updates price information from a Pricing instance
+   *
+   * @private
+   */
+  updatePriceFromPricing () {
+    this.config.display.amount = this.pricing.totalNow;
+    this.config.display.currency = this.pricing.currencyCode;
   }
 }

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -78,8 +78,6 @@ export default class Calculations {
     this.items = pricing.items;
     this._itemizedSets = { now: {}, next: {} };
 
-    this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
-
     this.price = {
       now: { items: [] },
       next: { items: [] },
@@ -255,7 +253,8 @@ export default class Calculations {
     // Taxation requires that we at least have base tax information
     if (isEmpty(baseTaxInfo)) return Promise.resolve();
 
-    const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
+    const getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
+    const getTaxesFor = item => getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
     const fixedAmount = amt => parseFloat(amt.toFixed(6));
     let taxRates = [];
 
@@ -265,7 +264,7 @@ export default class Calculations {
         taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
       });
     }))
-    .then(Promise.all(this.taxableSubscriptions.map(sub => {
+    .then(() => Promise.all(this.taxableSubscriptions.map(sub => {
       return getTaxesFor(sub).then(taxes => {
         taxRates = taxRates.concat(taxes);
         taxes.forEach(tax => {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -1,4 +1,3 @@
-import currencySymbolFor from 'currency-symbol-map';
 import each from 'component-each';
 import groupBy from 'lodash.groupby';
 import isEmpty from 'lodash.isempty';
@@ -86,8 +85,8 @@ export default class Calculations {
       //   adjustments: []
       // },
       currency: {
-        code: this.items.currency,
-        symbol: currencySymbolFor(this.items.currency)
+        code: this.currencyCode,
+        symbol: this.currencySymbol
       },
       taxes: []
     };

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -79,7 +79,6 @@ export default class Calculations {
 
     this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
 
-    // FIXME: set this structure functionally?
     this.price = {
       now: { items: [] },
       next: { items: [] },
@@ -108,7 +107,9 @@ export default class Calculations {
       .done(() => {
         each(this.price.now, decimalizeMember, this.price.now);
         each(this.price.next, decimalizeMember, this.price.next);
-        done(this.price)
+        this.price.now.items.forEach(item => each(item, decimalizeMember, item));
+        this.price.next.items.forEach(item => each(item, decimalizeMember, item));
+        done(this.price);
       });
   }
 

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -255,14 +255,17 @@ export default class Calculations {
 
     const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
     const fixedAmount = amt => parseFloat(amt.toFixed(6));
+    let taxRates = [];
 
     return Promise.all(this.taxableAdjustments.map(adj => {
       return getTaxesFor(adj).then(taxes => {
+        taxRates = taxRates.concat(taxes);
         taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
       });
     }))
     .then(Promise.all(this.taxableSubscriptions.map(sub => {
       return getTaxesFor(sub).then(taxes => {
+        taxRates = taxRates.concat(taxes);
         taxes.forEach(tax => {
           taxNow += fixedAmount(sub.price.now.subtotal * tax.rate);
           taxNext += fixedAmount(sub.price.next.subtotal * tax.rate);
@@ -271,6 +274,7 @@ export default class Calculations {
     })))
     .catch(err => this.pricing.emit('error', err))
     .then(() => {
+      this.price.taxes = uniq(taxRates);
       this.price.now.taxes = taxCeil(taxNow);
       this.price.next.taxes = taxCeil(taxNext);
     });

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -173,7 +173,7 @@ export default class Calculations {
     this.price.next.adjustments = 0; // always zero
     this._itemizedSets.now.adjustments = [];
 
-    this.items.adjustments.forEach(adjustment => {
+    this.validAdjustments.forEach(adjustment => {
       const { amount: unitAmount, quantity, code } = adjustment;
       const amount = unitAmount * quantity;
       const item = { type: 'adjustment', code, amount, quantity, unitAmount };

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash.isempty';
 import orderBy from 'lodash.orderby';
 import Promise from 'promise';
 import uniq from 'lodash.uniq';
+import uniqBy from 'lodash.uniqby';
 import decimalizeMember from '../../../util/decimalize-member';
 import taxCeil from '../../../util/tax-ceil';
 
@@ -275,7 +276,7 @@ export default class Calculations {
     })))
     .catch(err => this.pricing.emit('error', err))
     .then(() => {
-      this.price.taxes = uniq(taxRates);
+      this.price.taxes = uniqBy(taxRates, JSON.stringify);
       this.price.now.taxes = taxCeil(taxNow);
       this.price.next.taxes = taxCeil(taxNext);
     });
@@ -304,7 +305,7 @@ export default class Calculations {
       let used = 0;
       let remains = 0;
 
-      if (giftCardValue > price){
+      if (giftCardValue > price) {
         used = price;
         remains = giftCardValue - price;
       } else {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -113,11 +113,11 @@ export default class Calculations {
   }
 
   get validAdjustments () {
-    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+    return this.pricing.validAdjustments;
   }
 
   get validSubscriptions () {
-    return this.items.subscriptions.filter(sub => sub.isValid);
+    return this.pricing.validSubscriptions;
   }
 
   get hasValidSubscriptions () {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -199,7 +199,7 @@ export default class Calculations {
     this.price.next.discount = 0;
 
     // Remove all previously-applied coupons
-    this.items.subscriptions.forEach(sub => {
+    this.validSubscriptions.forEach(sub => {
       promise = promise.then(() => sub.coupon().reprice(null, { internal: true }))
     });
 

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -80,13 +80,9 @@ export default class Calculations {
     this.price = {
       now: { items: [] },
       next: { items: [] },
-      // base: {
-      //   subscriptions: [],
-      //   adjustments: []
-      // },
       currency: {
-        code: this.currencyCode,
-        symbol: this.currencySymbol
+        code: this.pricing.currencyCode,
+        symbol: this.pricing.currencySymbol
       },
       taxes: []
     };

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -1,9 +1,12 @@
 import currencySymbolFor from 'currency-symbol-map';
 import each from 'component-each';
 import groupBy from 'lodash.groupby';
+import isEmpty from 'lodash.isempty';
 import orderBy from 'lodash.orderby';
 import Promise from 'promise';
+import uniq from 'lodash.uniq';
 import decimalizeMember from '../../../util/decimalize-member';
+import taxCeil from '../../../util/tax-ceil';
 
 // Price structure
 //
@@ -74,6 +77,8 @@ export default class Calculations {
     this.items = pricing.items;
     this._itemizedSets = { now: {}, next: {} };
 
+    this.getTaxes = Promise.denodeify(this.pricing.recurly.tax.bind(this.pricing.recurly));
+
     // FIXME: set this structure functionally?
     this.price = {
       now: { items: [] },
@@ -86,7 +91,7 @@ export default class Calculations {
         code: this.items.currency,
         symbol: currencySymbolFor(this.items.currency)
       },
-      // taxes: []
+      taxes: []
     };
 
     // TODO: Instead of relying on ordering assumptions, it would be ideal to define each
@@ -107,12 +112,30 @@ export default class Calculations {
       });
   }
 
+  get validAdjustments () {
+    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+  }
+
   get validSubscriptions () {
     return this.items.subscriptions.filter(sub => sub.isValid);
   }
 
   get hasValidSubscriptions () {
     return this.validSubscriptions.length > 0;
+  }
+
+  get taxableAdjustments () {
+    return this.validAdjustments.filter(adj => !adj.taxExempt);
+  }
+
+  get taxableSubscriptions () {
+    return this.validSubscriptions.filter(sub => !sub.items.plan.tax_exempt);
+  }
+
+  // includes undefined entries
+  get taxCodes () {
+    const taxableItems = this.taxableAdjustments.concat(this.taxableSubscriptions);
+    return uniq(taxableItems.map(item => item.taxCode));
   }
 
   /**
@@ -183,13 +206,13 @@ export default class Calculations {
     if (!coupon) return promise;
 
     if (coupon.discount.rate) {
-      const {discountableNow, discountableNext} = this.discountableSubtotals(coupon, { setupFees: false });
+      const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
       this.price.now.discount = round(discountableNow * coupon.discount.rate);
       this.price.next.discount = round(discountableNext * coupon.discount.rate);
     } else if (coupon.discount.type === 'free_trial') {
       promise = promise.then(() => this.applyFreeTrialCoupon());
     } else {
-      const {discountableNow, discountableNext} = this.discountableSubtotals(coupon);
+      const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
       this.price.now.discount = Math.min(discountableNow, coupon.discount.amount[this.items.currency]);
       this.price.next.discount = Math.min(discountableNext, coupon.discount.amount[this.items.currency]);
     }
@@ -205,7 +228,7 @@ export default class Calculations {
    * @return {Promise}
    */
   subtotals () {
-    const {now, next} = this.price;
+    const { now, next } = this.price;
     this.price.now.subtotal = now.subscriptions + now.adjustments - now.discount;
     this.price.next.subtotal = next.subscriptions - next.discount;
     return Promise.resolve();
@@ -214,12 +237,43 @@ export default class Calculations {
   /**
    * Taxes
    *
+   * Workflow
+   * - collects tax rates for each tax code and the
+   *   base tax info (country, postal code, vat number)
+   * - applies taxes to each taxable item, according to its tax code
+   *
    * @return {Promise}
    */
   taxes () {
-    this.price.now.taxes = 0;
-    this.price.next.taxes = 0;
-    return Promise.resolve();
+    let taxNow = this.price.now.taxes = 0;
+    let taxNext = this.price.next.taxes = 0;
+
+    const baseTaxInfo = Object.assign({}, this.items.address, this.items.tax);
+
+    // Taxation requires that we at least have base tax information
+    if (isEmpty(baseTaxInfo)) return Promise.resolve();
+
+    const getTaxesFor = item => this.getTaxes(Object.assign({}, baseTaxInfo, { taxCode: item.taxCode }));
+    const fixedAmount = amt => parseFloat(amt.toFixed(6));
+
+    return Promise.all(this.taxableAdjustments.map(adj => {
+      return getTaxesFor(adj).then(taxes => {
+        taxNow += taxes.reduce((sum, tax) => sum + fixedAmount(adj.amount * adj.quantity * tax.rate), 0);
+      });
+    }))
+    .then(Promise.all(this.taxableSubscriptions.map(sub => {
+      return getTaxesFor(sub).then(taxes => {
+        taxes.forEach(tax => {
+          taxNow += fixedAmount(sub.price.now.subtotal * tax.rate);
+          taxNext += fixedAmount(sub.price.next.subtotal * tax.rate);
+        });
+      });
+    })))
+    .catch(err => this.pricing.emit('error', err))
+    .then(() => {
+      this.price.now.taxes = taxCeil(taxNow);
+      this.price.next.taxes = taxCeil(taxNext);
+    });
   }
 
   /**

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -43,6 +43,14 @@ export default class CheckoutPricing extends Pricing {
     return Calculations;
   }
 
+  get validAdjustments () {
+    return this.items.adjustments.filter(adj => adj.currency === this.items.currency);
+  }
+
+  get validSubscriptions () {
+    return this.items.subscriptions.filter(sub => sub.isValid);
+  }
+
   // Currency codes common to all subscriptions
   get subscriptionCurrencies () {
     return intersection(...this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
@@ -82,9 +90,15 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
-      debug('set.currency');
-      this.emit('set.currency', code);
-      resolve(code);
+      // Propagate currency changes to each subscription
+      Promise.all(this.validSubscriptions.map(sub => sub.currency(code).reprice()))
+        // Eject gift cards on currency change
+        .then(() => this.giftCard(null))
+        .then(() => {
+          debug('set.currency');
+          this.emit('set.currency', code);
+          resolve(code);
+        });
     }, this);
   }
 

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -82,10 +82,6 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
-      // FIXME: Need to propagate currency changes to each subscription
-      // FIXME: Need to swap out adjustments based on currency
-      // FIXME: eject gift cards on currency change
-
       debug('set.currency');
       this.emit('set.currency', code);
       resolve(code);

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -257,9 +257,8 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} address
    * @param {String} address.country
-   * @param {String|Number} address.postalCode
+   * @param {String} address.postalCode
    * @param {String} address.vatNumber
-   * @param {Function} [done] callback
    * @return {PricingPromise}
    * @public
    */
@@ -272,7 +271,6 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} tax
    * @param {String} tax.vatNumber
-   * @param {Function} [done] callback
    * @public
    */
   tax (tax) {

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -45,7 +45,7 @@ export default class CheckoutPricing extends Pricing {
 
   // Currency codes common to all subscriptions
   get subscriptionCurrencies () {
-    return intersection(this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
+    return intersection(...this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
   }
 
   // Plan codes of all subscriptions

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -271,7 +271,6 @@ export default class CheckoutPricing extends Pricing {
    * Updates tax info
    *
    * @param {Object} tax
-   * @param {String} tax.taxCode
    * @param {String} tax.vatNumber
    * @param {Function} [done] callback
    * @public

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -55,7 +55,7 @@ export default class CheckoutPricing extends Pricing {
 
   // Currency codes common to all subscriptions
   get subscriptionCurrencies () {
-    return intersection(...this.items.subscriptions.map(s => Object.keys(s.items.plan.price)));
+    return intersection(...this.validSubscriptions.map(s => Object.keys(s.items.plan.price)));
   }
 
   // Plan codes of all subscriptions
@@ -139,12 +139,12 @@ export default class CheckoutPricing extends Pricing {
       // If it cannot be resolved, reject the subscription
       if (this.items.currency && plan) {
         const planCurrencies = Object.keys(plan.price);
-        if (!~planCurrencies.indexOf(this.items.currency)) {
+        if (!~planCurrencies.indexOf(this.currencyCode)) {
           try {
             this.resolveCurrency(planCurrencies);
           } catch (e) {
             return this.error(errors('invalid-subscription-currency', {
-              checkoutCurrency: this.items.currency,
+              checkoutCurrency: this.currencyCode,
               checkoutSupportedCurrencies: this.subscriptionCurrencies,
               subscriptionPlanCurrencies: planCurrencies
             }), reject, 'currency');

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -165,12 +165,13 @@ export default class CheckoutPricing extends Pricing {
    * @param {Number}  adjustment.amount in unit price (1.0 for USD, etc)
    * @param {Number}  [adjustment.quantity=1] number of units
    * @param {String}  [adjustment.code=uuid()] unique identifier
+   * @param {String}  [adjustment.currency=this.items.currency] currency code
    * @param {Boolean} [adjustment.taxExempt=false] whether this adjustment is tax exempt
    * @param {String}  [adjustment.taxCode] taxation code
    * @return {PricingPromise}
    * @public
    */
-  adjustment ({amount, quantity = 1, code = uuid(), taxExempt = false, taxCode}) {
+  adjustment ({ amount, quantity = 1, code = uuid(), currency = this.items.currency, taxExempt = false, taxCode }) {
     return new PricingPromise((resolve, reject) => {
       amount = Number(amount);
       if (!isFinite(amount)) {
@@ -186,8 +187,7 @@ export default class CheckoutPricing extends Pricing {
       quantity = parseInt(quantity, 10);
       taxExempt = !!taxExempt;
 
-      let adjustment = { amount, quantity, code, taxExempt };
-      if (taxCode) adjustment.taxCode = taxCode;
+      const adjustment = { amount, quantity, code, currency, taxExempt, taxCode };
 
       this.items.adjustments.push(adjustment);
 
@@ -243,13 +243,13 @@ export default class CheckoutPricing extends Pricing {
    *
    * @param {Object} address
    * @param {String} address.country
-   * @param {String|Number} address.postal_code
-   * @param {String} address.vat_number
+   * @param {String|Number} address.postalCode
+   * @param {String} address.vatNumber
    * @param {Function} [done] callback
    * @return {PricingPromise}
    * @public
    */
-  address (address, done) {
+  address (address) {
     return new PricingPromise(this.itemUpdateFactory('address', address), this);
   }
 

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -13,16 +13,6 @@ import Calculations from './calculations';
 
 const debug = require('debug')('recurly:pricing:checkout-pricing');
 
-// FIXME: This is used by Pricing.remove, which must be updated for sets
-const PROPERTIES = [
-  'subscription',
-  'adjustment',
-  'coupon',
-  'address',
-  'currency',
-  'giftCard',
-];
-
 /**
  * checkoutPricing = recurly.Pricing.Checkout();
  */
@@ -31,7 +21,6 @@ export default class CheckoutPricing extends Pricing {
   constructor (...args) {
     super(...args);
     this.debug = debug;
-    this.PROPERTIES = PROPERTIES;
   }
 
   reset () {
@@ -42,6 +31,18 @@ export default class CheckoutPricing extends Pricing {
 
   get Calculations () {
     return Calculations;
+  }
+
+  get PRICING_METHODS () {
+    return super.PRICING_METHODS.concat([
+      'address',
+      'adjustment',
+      'coupon',
+      'currency',
+      'giftCard',
+      'subscription',
+      'tax'
+    ]);
   }
 
   get validAdjustments () {

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -137,7 +137,7 @@ export default class CheckoutPricing extends Pricing {
         }
       }
 
-      if (this.items.currency) this.currency(subscription.items.currency);
+      if (!this.items.currency) this.currency(subscription.items.currency);
 
       const addSubscription = () => {
         subscription.on('change:external', () => this.reprice());

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -1,6 +1,7 @@
 import intersection from 'lodash.intersection';
 import isEmpty from 'lodash.isempty';
 import isFinite from 'lodash.isfinite';
+import Promise from 'promise';
 import uniq from 'lodash.uniq';
 import errors from '../../../errors';
 import uuid from '../../../util/uuid';
@@ -83,7 +84,7 @@ export default class CheckoutPricing extends Pricing {
       if (!this.subscriptionsAllowCurrency(code)) {
         // TODO: Check the semantics of this error. Probably needs to be updated for CheckoutPricing
         return this.error(errors('invalid-currency', {
-          code,
+          currency: code,
           allowed: this.subscriptionCurrencies
         }), reject, 'currency');
       }

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -329,13 +329,16 @@ export default class CheckoutPricing extends Pricing {
   }
 
   /**
-   * Attempts to set a common currency from amongst the subscriptions and the provided code.
+   * Attempts to set a common currency from amongst the
+   * current subscriptions and the provided codes.
    *
    * @param {Array} code Array of {String} currency codes
+   * @param {Object} [options]
+   * @param {Boolean} [options.commit=true] whether to commit a currency change
    * @throws {Error} If a common currency cannot be found
    * @private
    */
-  resolveCurrency (codes) {
+  resolveCurrency (codes, { commit = true } = {}) {
     let commonCurrencies;
 
     // If we have subscriptions already, check that we have common currencies. Otherwise, we may proceed
@@ -346,6 +349,6 @@ export default class CheckoutPricing extends Pricing {
     }
 
     if (isEmpty(commonCurrencies)) throw new Error('unresolvable');
-    this.currency(commonCurrencies[0]);
+    if (commit) return this.currency(commonCurrencies[0]);
   }
 }

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -82,6 +82,10 @@ export default class CheckoutPricing extends Pricing {
 
       this.items.currency = code;
 
+      // FIXME: Need to propagate currency changes to each subscription
+      // FIXME: Need to swap out adjustments based on currency
+      // FIXME: eject gift cards on currency change
+
       debug('set.currency');
       this.emit('set.currency', code);
       resolve(code);
@@ -251,6 +255,19 @@ export default class CheckoutPricing extends Pricing {
    */
   address (address) {
     return new PricingPromise(this.itemUpdateFactory('address', address), this);
+  }
+
+  /**
+   * Updates tax info
+   *
+   * @param {Object} tax
+   * @param {String} tax.taxCode
+   * @param {String} tax.vatNumber
+   * @param {Function} [done] callback
+   * @public
+   */
+  tax (tax) {
+    return new PricingPromise(this.itemUpdateFactory('tax', tax), this);
   }
 
   /**

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -92,7 +92,10 @@ export default class CheckoutPricing extends Pricing {
       this.items.currency = code;
 
       // Propagate currency changes to each subscription
-      Promise.all(this.validSubscriptions.map(sub => sub.currency(code).reprice()))
+      Promise.all(this.validSubscriptions.map(sub => {
+        debug('checkout currency has changed. Updating subscription', sub);
+        return sub.currency(code).reprice();
+      }))
         // Eject gift cards on currency change
         .then(() => this.giftCard(null))
         .then(() => {

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -82,7 +82,6 @@ export default class CheckoutPricing extends Pricing {
     return new PricingPromise((resolve, reject) => {
       if (this.items.currency === code) return resolve(this.items.currency);
       if (!this.subscriptionsAllowCurrency(code)) {
-        // TODO: Check the semantics of this error. Probably needs to be updated for CheckoutPricing
         return this.error(errors('invalid-currency', {
           currency: code,
           allowed: this.subscriptionCurrencies
@@ -173,8 +172,6 @@ export default class CheckoutPricing extends Pricing {
 
   /**
    * Adds a one-time charge or credit a.k.a. adjustment
-   *
-   * - TODO: Finalize adjustment object format. Quantity?
    *
    * @param {Object}  adjustment
    * @param {Number}  adjustment.amount in unit price (1.0 for USD, etc)

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -130,12 +130,6 @@ export default class CheckoutPricing extends Pricing {
         return resolve(subscription);
       }
 
-      // FIXME: If a `subscription` plan changes, we must reject the plan if its currency is
-      //        not supported by all other subscriptions on the CheckoutPricing
-      //        - fix?: Add a change listener that errors the plan change.. would need a
-      //                hook on SubscriptionPricing.plan
-      //        - fix?: May want to wrap `subscription` in a new class that handles
-      //                CheckoutPricing-embedded SubscriptionPricings..
       const plan = subscription.items.plan;
 
       // If the subscription currencies do not match the checkout currency, attempt to resolve it.
@@ -159,7 +153,7 @@ export default class CheckoutPricing extends Pricing {
 
       const addSubscription = () => {
         subscription.on('change:external', () => this.reprice());
-        this.items.subscriptions.push(new EmbeddedSubscriptionPricing(subscription));
+        this.items.subscriptions.push(new EmbeddedSubscriptionPricing(subscription, this));
         debug('set.subscription');
         this.emit('set.subscription', subscription);
         resolve(subscription);

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -13,7 +13,7 @@ export class Pricing extends Emitter {
     this.recurly = recurly;
     this.debug = debug;
     this.reset();
-    // TODO: Add reprice call here?
+    this.reprice();
   }
 
   get Calculations () {
@@ -62,7 +62,7 @@ export class Pricing extends Emitter {
    * @param {Boolean} [options.internal] when true, the 'change:external' event is not emitted
    * @public
    */
-  reprice (done, { internal } = { internal: false }) {
+  reprice (done, { internal = false } = {}) {
     this.debug('reprice');
 
     return new PricingPromise((resolve, reject) => {

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -1,3 +1,4 @@
+import currencySymbolFor from 'currency-symbol-map';
 import Emitter from 'component-emitter';
 import find from 'component-find';
 import PricingPromise from './promise';
@@ -37,6 +38,10 @@ export class Pricing extends Emitter {
 
   get currencyCode () {
     return this.items.currency || '';
+  }
+
+  get currencySymbol () {
+    return currencySymbolFor(this.currencyCode);
   }
 
   /**

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -9,7 +9,6 @@ const debug = require('debug')('recurly:pricing');
 export class Pricing extends Emitter {
   constructor (recurly) {
     super();
-    this.PROPERTIES = [];
     this.recurly = recurly;
     this.debug = debug;
     this.reset();
@@ -18,6 +17,14 @@ export class Pricing extends Emitter {
 
   get Calculations () {
     throw new Error('Not implemented');
+  }
+
+  get PRICING_METHODS () {
+    return [
+      'reset',
+      'remove',
+      'reprice'
+    ];
   }
 
   get hasPrice () {
@@ -87,7 +94,7 @@ export class Pricing extends Emitter {
     return new PricingPromise((resolve, reject) => {
       let prop = Object.keys(opts)[0];
       let id = opts[prop];
-      if (!~this.PROPERTIES.indexOf(prop)) return this.error(errors('invalid-item'), reject);
+      if (!~Object.keys(this.items).indexOf(prop)) return this.error(errors('invalid-item'), reject);
       if (Array.isArray(this.items[prop])) {
         let pos = this.items[prop].indexOf(findByCode(this.items[prop], { code: id }));
         if (~pos) {

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -2,6 +2,7 @@ import Emitter from 'component-emitter';
 import find from 'component-find';
 import PricingPromise from './promise';
 import errors from '../../errors';
+import decimalize from '../../util/decimalize'
 
 const debug = require('debug')('recurly:pricing');
 
@@ -17,6 +18,18 @@ export class Pricing extends Emitter {
 
   get Calculations () {
     throw new Error('Not implemented');
+  }
+
+  get hasPrice () {
+    return !!this.price;
+  }
+
+  get totalNow () {
+    return decimalize(this.hasPrice ? this.price.now.total : 0);
+  }
+
+  get currencyCode () {
+    return this.items.currency || '';
   }
 
   /**

--- a/lib/recurly/pricing/promise.js
+++ b/lib/recurly/pricing/promise.js
@@ -21,6 +21,7 @@ const PRICING_METHODS = [
   'remove',
   'reprice',
   'giftcard',
+  'giftCard',
   'shippingAddress',
   'subscription',
   'adjustment'

--- a/lib/recurly/pricing/promise.js
+++ b/lib/recurly/pricing/promise.js
@@ -4,8 +4,6 @@ import partialRight from 'lodash.partialright';
 
 const debug = require('debug')('recurly:pricing:promise');
 
-module.exports = PricingPromise;
-
 /**
  * PricingPromise
  *
@@ -15,7 +13,7 @@ module.exports = PricingPromise;
  *
  * Usage
  *
- *   var pricing = recurly.Pricing();
+ *   let pricing = recurly.Pricing.Subscription();
  *
  *   pricing
  *     .plan('basic')
@@ -29,48 +27,42 @@ module.exports = PricingPromise;
  * @constructor
  * @public
  */
+export default class PricingPromise extends Promise {
+  constructor (resolver, pricing) {
+    debug('create');
+    super(resolver);
 
-function PricingPromise (resolver, pricing) {
-  if (!(this instanceof PricingPromise)) return new PricingPromise(resolver, pricing);
-  debug('create');
+    this.pricing = pricing;
+    this.constructor = partialRight(this.constructor, pricing);
 
-  this.pricing = pricing;
-  this.constructor = partialRight(this.constructor, pricing);
+    // for each pricing method, create a promise wrapper method
+    pricing && pricing.PRICING_METHODS.forEach(met => {
+      this[met] = (...args) => this.then(() => pricing[met](...args));
+    });
+  }
 
-  Promise.call(this, resolver);
+  /**
+   * Adds a reprice and completes the control flow
+   *
+   * @param {Function} onFulfilled
+   * @param {Function} onRejected
+   * @return {Pricing} bound pricing instance
+   * @public
+   */
+  done (...args) {
+    debug('repricing');
+    super.done.apply(this.then(this.reprice), args);
+    return this.pricing;
+  }
 
-  // for each pricing method, create a promise wrapper method
-  pricing && pricing.PRICING_METHODS.forEach(met => {
-    this[met] = (...args) => this.then(() => pricing[met](...args));
-  });
+  /**
+   * Adds a reprice if a callback is passed
+   *
+   * @param {Function} [done] callback
+   * @public
+   */
+  nodeify (done, ...args) {
+    if (typeof done === 'function') this.reprice();
+    return super.nodeify.call(this, done, ...args);
+  }
 }
-
-mixin(PricingPromise.prototype, Promise.prototype);
-PricingPromise.prototype.constructor = PricingPromise;
-
-/**
- * Adds a reprice and completes the control flow
- *
- * @param {Function} onFulfilled
- * @param {Function} onRejected
- * @return {Pricing} bound pricing instance
- * @public
- */
-
-PricingPromise.prototype.done = function () {
-  debug('repricing');
-  Promise.prototype.done.apply(this.then(this.reprice), arguments);
-  return this.pricing;
-};
-
-/**
- * Adds a reprice if a callback is passed
- *
- * @param {Function} [done] callback
- * @public
- */
-
-PricingPromise.prototype.nodeify = function (done) {
-  if (typeof done === 'function') this.reprice();
-  return Promise.prototype.nodeify.apply(this, arguments);
-};

--- a/lib/recurly/pricing/promise.js
+++ b/lib/recurly/pricing/promise.js
@@ -4,29 +4,6 @@ import partialRight from 'lodash.partialright';
 
 const debug = require('debug')('recurly:pricing:promise');
 
-/**
- * - FIXME: Should there be subclasses to handle SubscriptionPricing and
- *          CheckoutPricing? Perhaps the PRICING_METHODS should be read from
- *          the Pricing instances...
- */
-
-const PRICING_METHODS = [
-  'tax',
-  'plan',
-  'addon',
-  'coupon',
-  'address',
-  'currency',
-  'reset',
-  'remove',
-  'reprice',
-  'giftcard',
-  'giftCard',
-  'shippingAddress',
-  'subscription',
-  'adjustment'
-];
-
 module.exports = PricingPromise;
 
 /**
@@ -63,7 +40,9 @@ function PricingPromise (resolver, pricing) {
   Promise.call(this, resolver);
 
   // for each pricing method, create a promise wrapper method
-  PRICING_METHODS.forEach(met => this[met] = (...args) => this.then(() => pricing[met](...args)));
+  pricing && pricing.PRICING_METHODS.forEach(met => {
+    this[met] = (...args) => this.then(() => pricing[met](...args));
+  });
 }
 
 mixin(PricingPromise.prototype, Promise.prototype);

--- a/lib/recurly/pricing/subscription/attachment.js
+++ b/lib/recurly/pricing/subscription/attachment.js
@@ -9,7 +9,7 @@ const INIT_RUN = 'init-all';
 /**
  * bind a dom element to pricing values
  *
- * @param {Pricing} pricing
+ * @param {SubscriptionPricing} pricing
  * @param {HTMLElement} container Element on which to attach
  */
 

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -264,9 +264,6 @@ export default class Calculations {
     return price;
   }
 
-  // FIXME: when embedded on a checkout, respect a checkout-level trial coupon
-  //   - CheckoutPricing/Calculations determines trial eligibility of
-  //     a subscription. It must set a flag on the eligible subscription
   isTrial () {
     const coupon = this.items.coupon;
     if (coupon && coupon.discount.type === 'free_trial') return true;

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -26,8 +26,8 @@ export default class Calculations {
       },
       addons: {}, // DEPRECATED
       currency: {
-        code: this.currencyCode,
-        symbol: this.currencySymbol
+        code: this.pricing.currencyCode,
+        symbol: this.pricing.currencySymbol
       },
       taxes: []
     };
@@ -44,6 +44,10 @@ export default class Calculations {
       each(this.price.next, decimalizeMember, this.price.next);
       done(this.price);
     });
+  }
+
+  get taxExempt () {
+    return this.items.plan && this.items.plan.tax_exempt;
   }
 
   /**
@@ -103,7 +107,7 @@ export default class Calculations {
         } else {
           this.price.taxes = [];
           each(taxes, tax => {
-            if (this.items.plan.tax_exempt) return;
+            if (this.taxExempt) return;
             this.price.now.tax += parseFloat((this.price.now.subtotal * tax.rate).toFixed(6));
             this.price.next.tax += parseFloat((this.price.next.subtotal * tax.rate).toFixed(6));
             // If we have taxes, we may want to display the rate...
@@ -128,13 +132,19 @@ export default class Calculations {
    * @private
    */
   plan () {
-    var base = this.items.plan.price[this.items.currency];
+    this.price.now.plan = 0
+    this.price.next.plan = 0
+
+    if (!this.items.plan) return;
+
+    const base = this.items.plan.price[this.items.currency];
     this.price.base.plan.unit = base.unit_amount;
     this.price.base.plan.setup_fee = base.setup_fee;
 
-    var amount = this.planPrice().amount;
+    const amount = this.planPrice().amount;
     this.price.now.plan = amount;
     this.price.next.plan = amount;
+
     if (this.isTrial()) this.price.now.plan = 0;
   }
 
@@ -146,16 +156,14 @@ export default class Calculations {
   addons () {
     this.price.now.addons = 0;
     this.price.next.addons = 0;
-    // exclude usage addons.
-    if (!Array.isArray(this.items.plan.addons)) {
-      return;
-    }
 
-    let fixedAddons = this.items.plan.addons.filter(function(addon){
-      return addon.add_on_type === "fixed";
-    });
+    if (!this.items.plan) return;
+    if (!Array.isArray(this.items.plan.addons)) return;
 
-    fixedAddons.forEach((addon) => {
+    this.items.plan.addons.forEach(addon => {
+      // exclude usage addons
+      if (addon.add_on_type !== 'fixed') return;
+
       let price = addon.price[this.items.currency].unit_amount;
 
       this.price.base.addons[addon.code] = price;
@@ -243,14 +251,15 @@ export default class Calculations {
   }
 
   /**
-   * Get the price structure of a plan based on currency
+   * Get the price structure of the current plan on the current currency
    *
-   * @return {Object}
+   * @return {Object} { amount, setup_fee }
    * @private
    */
   planPrice () {
-    var plan = this.items.plan;
-    var price = plan.price[this.items.currency];
+    const plan = this.items.plan;
+    if (!plan) return { amount: 0, setup_fee: 0 };
+    let price = plan.price[this.items.currency];
     price.amount = price.unit_amount * (plan.quantity || 1);
     return price;
   }

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -26,8 +26,8 @@ export default class Calculations {
       },
       addons: {}, // DEPRECATED
       currency: {
-        code: this.items.currency,
-        symbol: this.planPrice().symbol
+        code: this.currencyCode,
+        symbol: this.currencySymbol
       },
       taxes: []
     };

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -2,7 +2,7 @@ import errors from '../../../errors';
 import PricingPromise from '../promise';
 import SubscriptionPricing from './';
 
-const DISABLED_METHODS = [
+export const DISABLED_METHODS = [
   'address',
   'coupon',
   'currency',
@@ -10,7 +10,7 @@ const DISABLED_METHODS = [
   'shippingAddress'
 ];
 
-const DEFERRED_METHODS = [
+export const DEFERRED_METHODS = [
   'couponIsValidForSubscription'
 ];
 

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -26,8 +26,9 @@ export const DEFERRED_METHODS = [
  * @constructor
  */
 export default class EmbeddedSubscriptionPricing {
-  constructor (subscriptionPricing) {
+  constructor (subscriptionPricing, checkoutPricing) {
     this.subscription = subscriptionPricing;
+    this.checkout = checkoutPricing;
 
     DISABLED_METHODS.forEach(method => {
       const original = subscriptionPricing[method];
@@ -36,8 +37,10 @@ export default class EmbeddedSubscriptionPricing {
     });
 
     DEFERRED_METHODS.forEach(method => {
-      this[method] = (...args) => this.subscription[method](...args);
+      this[method] = (...args) => subscriptionPricing[method](...args);
     });
+
+    subscriptionPricing.plan = this.plan.bind(this);
   }
 
   get isValid () {
@@ -54,6 +57,61 @@ export default class EmbeddedSubscriptionPricing {
 
   get taxCode () {
     return this.subscription.taxCode;
+  }
+
+  /**
+   * Plan setter
+   *
+   * - Overrides SubscriptionPricing.plan
+   * - Adds additional currency check before setting plan
+   * - Adds checkout currency resolution after the plan is set
+   *
+   * @param {String} planCode
+   * @param {Object} [meta]
+   * @param {Number} [meta.quantity]
+   * @param {Function} [done] callback
+   * @return {PricingPromise}
+   */
+  plan (...args) {
+    let { currentPlan, quantity, planCode, options, done } = this.subscription.resolvePlanOptions(...args);
+
+    return new PricingPromise((resolve, reject) => {
+      if (currentPlan && currentPlan.code === planCode) {
+        currentPlan.quantity = quantity;
+        return resolve(currentPlan);
+      }
+
+      this.checkout.recurly.plan(planCode, (err, plan) => {
+        if (err) return this.subscription.error(err, reject, 'plan');
+
+        // Check if the new plan will resolve with the checkout currencies
+        if (this.checkout.items.subscriptions.length > 1) {
+          try {
+            this.checkout.resolveCurrency(Object.keys(plan.price), { commit: false });
+          } catch (err) {
+            return reject(errors('invalid-plan-currency', {
+              planCode: plan.code,
+              currencies: this.checkout.subscriptionCurrencies
+            }));
+          }
+        }
+
+        plan.quantity = quantity;
+        this.subscription.items.plan = plan;
+
+        // Update checkout currency, which will update the subscription currency
+        if (this.checkout.currencyCode in plan.price) return resolve();
+
+        // update currencies on checkout, which will propagate the
+        // change to the subscriptions
+        this.checkout.resolveCurrency(Object.keys(plan.price))
+          .then(() => {
+            this.subscription.emit('set.plan', plan);
+            resolve(plan);
+          })
+          .catch(err => reject(err));
+      });
+    }, this.subscription).nodeify(done);
   }
 }
 

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -3,9 +3,10 @@ import PricingPromise from '../promise';
 import SubscriptionPricing from './';
 
 const DISABLED_METHODS = [
-  'coupon',
-  'giftcard',
   'address',
+  'coupon',
+  'currency',
+  'giftcard',
   'shippingAddress'
 ];
 
@@ -49,6 +50,10 @@ export default class EmbeddedSubscriptionPricing {
 
   get price () {
     return this.subscription.price;
+  }
+
+  get taxCode () {
+    return this.subscription.taxCode;
   }
 }
 

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -42,7 +42,7 @@ export default class SubscriptionPricing extends Pricing {
   }
 
   get isValid () {
-    return this.items.plan && this.price;
+    return !!(this.items.plan && this.price);
   }
 
   get taxCode () {
@@ -224,9 +224,6 @@ export default class SubscriptionPricing extends Pricing {
 
   /**
    * Updates coupon
-   *
-   * FIXME: prevent external coupon assignment when embedded in a
-   *        CheckoutPricing
    *
    * @param {String} newCoupon coupon code
    * @param {Object} newCoupon coupon object

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -10,9 +10,6 @@ const debug = require('debug')('recurly:pricing:subscription-pricing');
 /**
  * SubscriptionPricing
  *
- * TODO: Add a trigger to disable coupons, gift cards, addresses, and currency
- *       if this is embedded into a CheckoutPricing
- *
  * @constructor
  * @param {Recurly} recurly
  * @public
@@ -74,6 +71,7 @@ export default class SubscriptionPricing extends Pricing {
    * @param {Object} [meta]
    * @param {Number} [meta.quantity]
    * @param {Function} [done] callback
+   * @return {PricingPromise}
    * @public
    */
   plan (...args) {

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -76,50 +76,36 @@ export default class SubscriptionPricing extends Pricing {
    * @param {Function} [done] callback
    * @public
    */
-  plan (planCode, meta, done) {
-    const self = this;
-    let plan = this.items.plan;
-    let quantity;
+  plan (...args) {
+    let { currentPlan, quantity, planCode, options, done } = this.resolvePlanOptions(...args);
 
-    if (typeof meta === 'function') {
-      done = meta;
-      meta = undefined;
-    }
-
-    meta = meta || {};
-
-    // meta.quantity, plan.quantity, 1
-    if (plan && plan.quantity) quantity = plan.quantity;
-    if (meta.quantity) quantity = parseInt(meta.quantity, 10);
-    if (!quantity || quantity < 1) quantity = 1;
-
-    return new PricingPromise(function (resolve, reject) {
-      if (plan && plan.code === planCode) {
-        plan.quantity = quantity;
-        return resolve(plan);
+    return new PricingPromise((resolve, reject) => {
+      if (currentPlan && currentPlan.code === planCode) {
+        currentPlan.quantity = quantity;
+        return resolve(currentPlan);
       }
 
-      self.recurly.plan(planCode, function (err, plan) {
-        if (err) return self.error(err, reject, 'plan');
+      this.recurly.plan(planCode, (err, plan) => {
+        if (err) return this.error(err, reject, 'plan');
+
+        const finish = () => {
+          debug('set.plan');
+          this.emit('set.plan', plan);
+          resolve(plan);
+        };
 
         plan.quantity = quantity;
-        self.items.plan = plan;
+        this.items.plan = plan;
 
-        if (!(self.items.currency in plan.price)) {
-          self.currency(Object.keys(plan.price)[0]);
+        if (!(this.items.currency in plan.price)) {
+          this.currency(Object.keys(plan.price)[0]);
         }
 
         // If we have a coupon, it must be reapplied
-        if (self.items.coupon) {
-          self.coupon(self.items.coupon.code).then(finish, finish);
+        if (this.items.coupon) {
+          this.coupon(this.items.coupon.code).then(finish, finish);
         } else {
           finish();
-        }
-
-        function finish () {
-          debug('set.plan');
-          self.emit('set.plan', plan);
-          resolve(plan);
         }
       });
     }, this).nodeify(done);
@@ -353,6 +339,31 @@ export default class SubscriptionPricing extends Pricing {
     if (coupon.applies_to_all_plans) return true;
     if (~coupon.plans.indexOf(this.items.plan.code)) return true;
     return false;
+  }
+
+  /**
+   * Parses plan method options
+   *
+   * @param  {String}   planCode
+   * @param  {Object}   [options]
+   * @param  {Function} done
+   * @return {object}
+   */
+  resolvePlanOptions (planCode, options = {}, done) {
+    let plan = this.items.plan;
+    let quantity;
+
+    if (typeof options === 'function') {
+      done = options;
+      options = {};
+    }
+
+    // options.quantity, plan.quantity, 1
+    if (plan && plan.quantity) quantity = plan.quantity;
+    if (options.quantity) quantity = parseInt(options.quantity, 10);
+    if (!quantity || quantity < 1) quantity = 1;
+
+    return { currentPlan: plan, quantity, planCode, options, done };
   }
 }
 

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -43,6 +43,11 @@ export default class SubscriptionPricing extends Pricing {
     return this.items.plan && this.price;
   }
 
+  get taxCode () {
+    if (!this.items.tax) return;
+    return this.items.tax.tax_code;
+  }
+
   reset () {
     super.reset();
     this.items.addons = [];

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -45,7 +45,7 @@ export default class SubscriptionPricing extends Pricing {
 
   get taxCode () {
     if (!this.items.tax) return;
-    return this.items.tax.tax_code;
+    return this.items.tax.taxCode || this.items.tax.tax_code;
   }
 
   reset () {
@@ -303,8 +303,10 @@ export default class SubscriptionPricing extends Pricing {
    * Updates tax info
    *
    * @param {Object} tax
-   * @param {String} tax.tax_code
-   * @param {String} tax.vat_number
+   * @param {String} tax.taxCode
+   * @param {String} tax.vatNmber
+   * @param {String} tax.tax_code // deprecated
+   * @param {String} tax.vat_number // deprecated
    * @param {Function} [done] callback
    * @public
    */

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -346,18 +346,6 @@ export default class SubscriptionPricing extends Pricing {
   }
 
   /**
-   * Ensures a plan is set before repricing
-   *
-   * @return {PricingPromise}
-   */
-  reprice (...args) {
-    return new PricingPromise((resolve, reject) => {
-      if (!this.items.plan) return this.error(errors('missing-plan'), reject, 'plan');
-      else return resolve(super.reprice(...args));
-    });
-  }
-
-  /**
    * Checks whether a given coupon may apply to this subscription
    * @param  {Object} coupon
    * @return {Boolean}

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -7,16 +7,6 @@ import uuid from '../../../util/uuid';
 
 const debug = require('debug')('recurly:pricing:subscription-pricing');
 
-const PROPERTIES = [
-  'plan',
-  'addon',
-  'coupon',
-  'address',
-  'currency',
-  'gift_card',
-  'shipping_address'
-];
-
 /**
  * SubscriptionPricing
  *
@@ -32,11 +22,23 @@ export default class SubscriptionPricing extends Pricing {
     super(...args);
     this.id = uuid();
     this.debug = debug;
-    this.PROPERTIES = PROPERTIES;
   }
 
   get Calculations () {
     return Calculations;
+  }
+
+  get PRICING_METHODS () {
+    return super.PRICING_METHODS.concat([
+      'addon',
+      'address',
+      'coupon',
+      'currency',
+      'giftcard',
+      'plan',
+      'shippingAddress',
+      'tax'
+    ]);
   }
 
   get isValid () {

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -328,7 +328,7 @@ export default class SubscriptionPricing extends Pricing {
       if (currency === code) return resolve(currency);
       if (plan && !(code in plan.price)) {
         return self.error(errors('invalid-currency', {
-          code,
+          currency: code,
           allowed: Object.keys(plan.price)
         }), reject, 'currency');
       }

--- a/lib/recurly/tax.js
+++ b/lib/recurly/tax.js
@@ -1,11 +1,7 @@
-var clone = require('component-clone');
-
-module.exports = tax;
-
 /**
- * Tax mixin.
+ * Tax getter
  *
- * Provides a tax estimate for the given address.
+ * Provides a tax estimate for the given tax info.
  *
  * @param {Object} options
  * @param {Object} options.postal_code
@@ -15,16 +11,17 @@ module.exports = tax;
  * @param {Function} callback
  */
 
-function tax (options, callback) {
-  var request = clone(options);
+export default function tax (options, done) {
+  options = Object.assign({}, options);
 
-  if (typeof callback !== 'function') {
+  if (typeof done !== 'function') {
     throw new Error('Missing callback');
   }
 
-  if (!('currency' in request)) {
-    request.currency = this.config.currency;
-  }
-
-  this.request('get', '/tax', request, callback);
+  this.cachedRequest('get', '/tax', {
+    country: options.country,
+    postal_code: (options.postalCode || options.postal_code),
+    tax_code: (options.taxCode || options.tax_code),
+    vat_number: (options.vatNumber || options.vat_number)
+  }, done);
 };

--- a/lib/util/decimalize-member.js
+++ b/lib/util/decimalize-member.js
@@ -1,3 +1,5 @@
+import decimalize from './decimalize';
+
 /**
  * Applies a decimal transform on an object's member
  *
@@ -7,5 +9,5 @@
 
 export default function decimalizeMember (prop) {
   if (typeof this[prop] !== 'number') return;
-  this[prop] = (Math.round(Math.max(this[prop], 0) * 100) / 100).toFixed(2);
+  this[prop] = decimalize(this[prop]);
 }

--- a/lib/util/decimalize.js
+++ b/lib/util/decimalize.js
@@ -1,0 +1,9 @@
+/**
+ * Applies a decimal transform
+ *
+ * @param {Number} number to transform
+ */
+
+export default function decimalize (number) {
+  return (Math.round(Math.max(number, 0) * 100) / 100).toFixed(2);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5442,6 +5442,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+    },
     "log-symbols": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash.partialright": "^4.2.1",
     "lodash.pick": "^4.4.0",
     "lodash.uniq": "^4.5.0",
+    "lodash.uniqby": "^4.7.0",
     "mixin": "https://github.com/kewah/mixin#0.1.0",
     "promise": "7.1.1",
     "qs": "0.6.6",

--- a/test/apple-pay.test.js
+++ b/test/apple-pay.test.js
@@ -115,7 +115,7 @@ apiTest(function (requestMethod) {
       describe('when given options.pricing', function () {
         beforeEach(function () {
           let pricing = this.pricing = this.recurly.Pricing();
-          this.applePay = this.recurly.ApplePay(merge(omit(validOpts, 'total'), { pricing }))
+          this.applePay = this.recurly.ApplePay(merge({}, validOpts, { pricing }))
         });
 
         it('binds a pricing instance', function (done) {
@@ -127,7 +127,7 @@ apiTest(function (requestMethod) {
 
         it('ignores options.total', function (done) {
           this.applePay.ready(() => {
-            assert(!('total' in this.applePay.config));
+            assert.notEqual(this.applePay.config.total, validOpts.total);
             done();
           });
         });

--- a/test/paypal/strategy/strategy.test.js
+++ b/test/paypal/strategy/strategy.test.js
@@ -54,8 +54,9 @@ apiTest(function (requestMethod) {
       });
 
       it('updates display properties when pricing changes', function (done) {
-        assert.equal(typeof this.paypal.strategy.config.display.amount, 'undefined');
+        assert.equal(this.paypal.strategy.config.display.amount, 0);
         this.pricing.plan('basic').done(price => {
+          assert.notEqual(this.paypal.strategy.config.display.amount, 0);
           assert.equal(this.paypal.strategy.config.display.amount, price.now.total);
           assert.equal(this.paypal.strategy.config.display.currency, price.currency.code);
           done();

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -586,6 +586,63 @@ describe('CheckoutPricing', function () {
   });
 
   /**
+   * Currency
+   */
+
+  describe('CheckoutPricing#currency', () => {
+    it('Updates the CheckoutPricing and constituent subscription currencies', function (done) {
+      this.pricing
+        .subscription(this.subscriptionPricingExample)
+        .reprice()
+        .then(price => {
+          assert.equal(price.currency.code, 'USD');
+          assert.equal(this.subscriptionPricingExample.price.currency.code, 'USD');
+        })
+        .currency('EUR')
+        .done(price => {
+          assert.equal(price.currency.code, 'EUR');
+          assert.equal(this.subscriptionPricingExample.price.currency.code, 'EUR');
+          done();
+        });
+    });
+
+    it('throws an error when given a currency not supported by the subscriptions', function (done) {
+      this.pricing
+        .subscription(this.subscriptionPricingExample)
+        .currency('GBP')
+        .catch(err => {
+          assert.equal(err.code, 'invalid-currency');
+          assert.equal(this.pricing.price.currency.code, 'USD');
+          done();
+        })
+        .done();
+    });
+
+    it('emits set.currency if the currency changes', function () {
+      assert.equal(this.pricing.price.currency.code, 'USD');
+      this.pricing.on('set.currency', code => {
+        assert.equal(code, 'EUR');
+        assert.equal(this.pricing.price.currency.code, 'EUR');
+        done();
+      });
+      this.pricing.currency('EUR');
+    });
+
+    it('removes a gift card if the currency changes', function () {
+      this.pricing
+        .giftCard('super-gift-card')
+        .then(() => {
+          assert.equal(typeof this.pricing.giftCard, 'object');
+        })
+        .currency('EUR')
+        .done(() => {
+          assert.equal(this.pricing.giftCard, undefined);
+          done();
+        });
+    });
+  });
+
+  /**
    * Gift cards
    */
 

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -586,7 +586,7 @@ describe('CheckoutPricing', function () {
   });
 
   /**
-   * Subscriptions
+   * Gift cards
    */
 
   describe('CheckoutPricing#giftCard', () => {
@@ -669,10 +669,16 @@ describe('CheckoutPricing', function () {
   });
 
   /**
-   * address - TODO
+   * Address
    */
 
   describe('CheckoutPricing#address', () => {});
+
+  /**
+   * Taxes
+   */
+
+  describe('CheckoutPricing#tax', () => {});
 });
 
 function subscriptionPricingFactory (planCode = 'basic', recurly, done) {

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -1001,3 +1001,9 @@ function applyGiftCard (code) {
     });
   }
 }
+
+function applyGiftCard (code) {
+  return function (done) {
+    this.pricing.giftCard(code).done(() => done());
+  }
+}

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -876,6 +876,7 @@ describe('CheckoutPricing', function () {
             assert.equal(price.next.subtotal, 19.99);
             assert.equal(price.next.taxes, 1.75); // 8.75% of 19.99
             assert.equal(price.next.total, 21.74);
+
             assert.equal(price.taxes.length, 1);
             assert(Array.isArray(price.taxes));
             done();
@@ -1003,7 +1004,9 @@ function applyGiftCard (code) {
 }
 
 function applyGiftCard (code) {
-  return function (done) {
-    this.pricing.giftCard(code).done(() => done());
+  return function () {
+    return this.pricing.giftCard(code).reprice().then(price => {
+      this.price = price;
+    });
   }
 }

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -7,7 +7,6 @@ describe('CheckoutPricing', function () {
   beforeEach(function (done) {
     this.recurly = initRecurly();
     this.pricing = this.recurly.Pricing.Checkout();
-    this.pricing.reprice(); // should not be necessary once reprice is updated
 
     subscriptionPricingFactory('multiple-currencies', this.recurly, sub => {
       this.subscriptionPricingExample = sub;
@@ -39,9 +38,8 @@ describe('CheckoutPricing', function () {
         .subscription(this.subscriptionPricingExample)
         .done(price => {
           assert.equal(this.pricing.price.now.items.length, 1);
-          // TODO: This is not final. float parsing should not be necessary
-          assert.equal(price.now.total, parseFloat(subscriptionTotalNow));
-          assert.equal(price.next.total, parseFloat(subscriptionTotalNext));
+          assert.equal(price.now.total, subscriptionTotalNow);
+          assert.equal(price.next.total, subscriptionTotalNext);
           done();
         });
     });

--- a/test/pricing/subscription/embedded.test.js
+++ b/test/pricing/subscription/embedded.test.js
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import SubscriptionPricing from '../../../lib/recurly/pricing/subscription';
+import EmbeddedSubscriptionPricing, {DISABLED_METHODS, DEFERRED_METHODS} from '../../../lib/recurly/pricing/subscription/embedded';
+import {initRecurly} from '../../support/helpers';
+
+describe('EmbeddedSubscriptionPricing', () => {
+  beforeEach(function () {
+    this.recurly = initRecurly();
+    this.subscriptionPricingDefault = this.recurly.Pricing.Subscription();
+    this.subscriptionPricing = this.recurly.Pricing.Subscription();
+    this.embeddedSubscriptionPricing = new EmbeddedSubscriptionPricing(this.subscriptionPricing);
+  });
+
+  describe('disabling methods', () => {
+    it('Disables methods on the SubscriptionPricing instance', function () {
+      DISABLED_METHODS.forEach(method => {
+        assert.equal(this.subscriptionPricingDefault[method], SubscriptionPricing.prototype[method]);
+        assert.notEqual(this.subscriptionPricing[method], SubscriptionPricing.prototype[method]);
+      });
+    });
+
+    it('proxies the disabled methods onto the EmbeddedSubscriptionPricing instance', function () {
+      DISABLED_METHODS.forEach(method => {
+        assert.equal(this.embeddedSubscriptionPricing[method].name, SubscriptionPricing.prototype[method].name);
+      });
+    });
+  });
+
+  describe('deferred methods', () => {
+    it('calls the methods on the SubscriptionPricing instance', function () {
+      DEFERRED_METHODS.forEach(method => {
+        sinon.stub(this.subscriptionPricing, method);
+        this.embeddedSubscriptionPricing[method](1);
+        assert(this.subscriptionPricing[method].calledOnce);
+        assert(this.subscriptionPricing[method].calledWith(1));
+      });
+    });
+  });
+});

--- a/test/pricing/subscription/embedded.test.js
+++ b/test/pricing/subscription/embedded.test.js
@@ -8,6 +8,14 @@ describe('EmbeddedSubscriptionPricing', () => {
     this.recurly = initRecurly();
     this.subscriptionPricingDefault = this.recurly.Pricing.Subscription();
     this.subscriptionPricing = this.recurly.Pricing.Subscription();
+
+    // Spies
+    this.originalMethods = {};
+    DISABLED_METHODS.forEach(method => {
+      sinon.stub(this.subscriptionPricing, method);
+      this.originalMethods[method] = this.subscriptionPricing[method];
+    });
+
     this.embeddedSubscriptionPricing = new EmbeddedSubscriptionPricing(this.subscriptionPricing);
   });
 
@@ -16,12 +24,25 @@ describe('EmbeddedSubscriptionPricing', () => {
       DISABLED_METHODS.forEach(method => {
         assert.equal(this.subscriptionPricingDefault[method], SubscriptionPricing.prototype[method]);
         assert.notEqual(this.subscriptionPricing[method], SubscriptionPricing.prototype[method]);
+
+        // Calling the method does not invoke its original form
+        this.subscriptionPricing[method]();
+        assert(this.originalMethods[method].notCalled);
       });
     });
 
     it('proxies the disabled methods onto the EmbeddedSubscriptionPricing instance', function () {
       DISABLED_METHODS.forEach(method => {
-        assert.equal(this.embeddedSubscriptionPricing[method].name, SubscriptionPricing.prototype[method].name);
+        assert.equal(this.subscriptionPricingDefault[method].prototype, SubscriptionPricing.prototype[method].prototype);
+
+        // Loose assertion that this is now a bound method
+        assert.equal(typeof this.embeddedSubscriptionPricing[method], 'function');
+        assert.equal(this.embeddedSubscriptionPricing[method].prototype, undefined);
+
+        // Calling the method does invoke its original
+        assert(this.originalMethods[method].notCalled);
+        this.embeddedSubscriptionPricing[method]();
+        assert(this.originalMethods[method].calledOnce);
       });
     });
   });

--- a/test/recurly.test.js
+++ b/test/recurly.test.js
@@ -1,7 +1,9 @@
 import assert from 'assert';
+import isEmpty from 'lodash.isempty';
 import {Recurly} from '../lib/recurly';
 import CheckoutPricing from '../lib/recurly/pricing/checkout';
 import SubscriptionPricing from '../lib/recurly/pricing/subscription';
+import {initRecurly} from './support/helpers';
 
 describe('Recurly', () => {
   let recurly;
@@ -29,15 +31,7 @@ describe('Recurly', () => {
   });
 
   describe('Recurly.request', () => {
-    let cors = false;
-
-    beforeEach(() => {
-      recurly.configure({
-        publicKey: 'test',
-        api: `//${global.location.host}/api`,
-        cors: cors
-      });
-    });
+    beforeEach(() => recurly = initRecurly({ cors: false }));
 
     describe('when configured for jsonp requests', () => {
       it('invokes recurly.jsonp', () => {
@@ -48,12 +42,127 @@ describe('Recurly', () => {
     });
 
     describe('when configured for cors requests', () => {
-      before(() => cors = true);
+      beforeEach(() => recurly = initRecurly({ cors: true }));
 
       it('invokes recurly.xhr', () => {
         sinon.stub(recurly, 'xhr');
         recurly.request('get', 'test', () => {});
         assert(recurly.xhr.calledOnce);
+      });
+    });
+  });
+
+  describe('Recurly.cachedRequest', () => {
+    const noop = () => {};
+    const payload = { arbitrary: 'payload' };
+
+    beforeEach(() => recurly = initRecurly());
+
+    it('on first call, invokes recurly.request with identical parameters', () => {
+      sinon.stub(recurly, 'request');
+      recurly.cachedRequest('get', 'test', payload, noop);
+      assert(recurly.request.calledOnce);
+      assert(recurly.request.calledWith('get', 'test', payload));
+    });
+
+    it('returns and does not cache error responses', done => {
+      recurly.cachedRequest('get', 'test', payload, (err, res) => {
+        assert(err);
+        assert(isEmpty(recurly._cachedRequests));
+        done();
+      });
+    });
+
+    describe('given a successful response', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, null, { success: true });
+      });
+
+      it('returns and caches successful responses', done => {
+        recurly.cachedRequest('get', 'test', payload, (err, res) => {
+          assert.equal(err, null);
+          assert.equal(res.success, true);
+          assert.equal(Object.keys(recurly._cachedRequests).length, 1);
+          done();
+        });
+      });
+
+      it(`invokes recurly.request on the first call, and not on the
+          second, with identical responses for both requests`, done => {
+        recurly.cachedRequest('get', 'test', payload, (err, res) => {
+          assert(recurly.request.calledOnce);
+          recurly.cachedRequest('get', 'test', payload, (err, res) => {
+            assert(recurly.request.calledOnce);
+            assert.equal(Object.keys(recurly._cachedRequests).length, 1);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('Recurly.pipedRequest', () => {
+    const noop = () => {};
+    let payload = {
+      long: Array.apply(null, Array(200)).map(() => 1)
+    }
+
+    beforeEach(() => recurly = initRecurly());
+
+    describe('given all error responses', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, { code: 'not-found'}, null);
+      });
+
+      it('responds with an error', () => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .catch(err => {
+            assert.equal(err.code, 'not-found');
+            done();
+          })
+      });
+    });
+
+    describe('given successful responses', () => {
+      beforeEach(() => {
+        sinon.stub(recurly, 'request');
+        recurly.request.callsArgWith(3, null, { success: true });
+      });
+
+      it('spreads a long request set across multiple requests with a default size of 100', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .done(() => {
+            assert(recurly.request.calledTwice);
+            done();
+          })
+      });
+
+      it('spreads a long request set across multiple requests with given a custom size', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long', size: 10 })
+          .done(() => {
+            assert.equal(recurly.request.callCount, 20);
+            done();
+          })
+      });
+
+      it('responds with the first response if it is an object', done => {
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long' })
+          .done(res => {
+            assert.equal(res.success, true);
+            done();
+          })
+      });
+
+      it('responds with a flattened response set if the responses are arrays', done => {
+        recurly.request.callsArgWith(3, null, [{ success: true }]);
+        recurly.pipedRequest({ method: 'get', route: 'test', data: payload, by: 'long', size: 10 })
+          .done(set => {
+            assert.equal(set.length, 20);
+            set.forEach(res => assert.equal(res.success, true));
+            done();
+          })
       });
     });
   });

--- a/test/server/fixtures/plans/basic-gbp.json
+++ b/test/server/fixtures/plans/basic-gbp.json
@@ -1,0 +1,16 @@
+{
+  "code": "basic-gbp",
+  "name": "Basic GBP",
+  "period": {
+    "interval": "months",
+    "length": 1
+  },
+  "price": {
+    "GBP": {
+      "setup_fee": 0,
+      "unit_amount": 14.0
+    }
+  },
+  "addons": [],
+  "tax_exempt": false
+}

--- a/test/server/fixtures/tax/index.js
+++ b/test/server/fixtures/tax/index.js
@@ -3,26 +3,32 @@
  * postal code to match for US sales tax
  */
 
-var USST_POSTAL_CODE = '94110';
+const USST_POSTAL_CODE = '94110';
 
 /**
  * postal code to match for US sales tax
  * with region data returned
  */
 
-var USST_POSTAL_CODE_WITH_REGION = '94129';
+const USST_POSTAL_CODE_WITH_REGION = '94129';
+
+/**
+ * tax code to match for code exception example
+ */
+
+const USST_TAX_CODE = 'valid-tax-code';
 
 /**
  * country code to match for VAT
  */
 
-var VAT_COUNTRY = 'DE';
+const VAT_COUNTRY = 'DE';
 
 /**
  * country code to match for VAT 2015
  */
 
-var VAT_2015_COUNTRY = 'GB';
+const VAT_2015_COUNTRY = 'GB';
 
 /**
  * US sales tax response
@@ -37,6 +43,7 @@ var VAT_2015_COUNTRY = 'GB';
  */
 
 module.exports = function tax () {
+  if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE && this.query.tax_code === USST_TAX_CODE) return usstWithTaxCode;
   if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE) return usst;
   if (this.query.country === 'US' && this.query.postal_code === USST_POSTAL_CODE_WITH_REGION) return usstWithRegion;
   if (this.query.country === VAT_COUNTRY) return vat;
@@ -44,23 +51,28 @@ module.exports = function tax () {
   return none;
 };
 
-var usst = [{
+const usst = [{
   type: 'us',
   rate: '0.0875'
 }];
 
-var usstWithRegion = [{
+const usstWithRegion = [{
   type: 'us',
   rate: '0.0875',
   region: 'CA'
 }];
 
-var vat = [{
+const usstWithTaxCode = [{
+  type: 'us',
+  rate: '0.02'
+}]
+
+const vat = [{
   type: 'vat',
   rate: '0.015'
 }];
 
-var vat2015 = [{
+const vat2015 = [{
   type: 'vat',
   rate: '0.2',
   region: 'GB'


### PR DESCRIPTION
#### Description

- **To follow #393** - includes `SubscriptionPricing` taxation methods and calculations, and adjustment currency determinations and calculations
- Adds `Pricing.totalNow` and `Pricing.currencyCode`
- Adapts `ApplePay` and `PayPalStrategy` base class to read `Pricing.totalNow` and `Pricing.currencyCode`
- Updates `PricingPromise` to the class pattern

#### Example - PayPal

```js
var checkoutPricing = recurly.Pricing.Checkout();
var payPal = recurly.PayPal({ pricing: checkoutPricing });

// checkoutPricing manipulations: add subscriptions, adjustments. coupons, gift cards, address info, tax info, etc

$('#my-checkout-form').on('submit', function (event) {
  event.preventDefault();

  // PayPal express checkout window will open with current Pricing totals and currency
  payPal.start();
});
```

#### Example - ApplePay

```js
var checkoutPricing = recurly.Pricing.Checkout();
var applePay = recurly.ApplePay({ pricing: checkoutPricing });

// checkoutPricing manipulations: add subscriptions, adjustments. coupons, gift cards, address info, tax info, etc

$('#my-apple-pay-button').on('click', function (event) {
  event.preventDefault();

  // Apple Pay dialogue will open with current Pricing totals and currency
  applePay.start();
});
````