### PR TITLE
Removes lodash.after dependency from BraintreeStrategy

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -32,6 +32,13 @@ export function factory (options) {
  * Initializes an Apple Pay session.
  *
  * @param {Object} options
+ * @param {Recurly} options.recurly
+ * @param {String} options.country
+ * @param {String} options.currency
+ * @param {String} options.label label to display to customers in the Apple Pay dialogue
+ * @param {String} options.total transaction total in format '1.00'
+ * @param {HTMLElement} [options.form] to provide additional customer data
+ * @param {Pricing} [options.pricing] to provide transaction total from Pricing
  * @constructor
  * @public
  */

--- a/lib/recurly/paypal/strategy/braintree.js
+++ b/lib/recurly/paypal/strategy/braintree.js
@@ -1,5 +1,5 @@
-import after from 'lodash.after';
 import loadScript from 'load-script';
+import after from '../../../util/after';
 import {PayPalStrategy} from './index';
 
 const debug = require('debug')('recurly:paypal:strategy:braintree');
@@ -32,8 +32,7 @@ export class BraintreeStrategy extends PayPalStrategy {
   load () {
     debug('loading Braintree libraries');
 
-    const initialize = this.initialize.bind(this);
-    const part = after(2, initialize);
+    const part = after(2, () => this.initialize());
     const get = (lib, done = () => {}) => {
       const uri = `https://js.braintreegateway.com/web/${BRAINTREE_CLIENT_VERSION}/js/${lib}.min.js`;
       loadScript(uri, error => {

--- a/lib/util/after.js
+++ b/lib/util/after.js
@@ -1,0 +1,11 @@
+/**
+ * Returns a function which calls the callback after x calls
+ *
+ * @param  {Number} count
+ * @param  {Function} done
+ * @return {Function}
+ */
+export default function after (count = 0, done) {
+  let i = 0;
+  return () => i++ && i === count && done();
+}

--- a/lib/util/deep-assign.js
+++ b/lib/util/deep-assign.js
@@ -5,7 +5,7 @@
  * @param ...sources
  */
 
-export default function mergeDeep (target, ...sources) {
+export default function deepAssign (target, ...sources) {
   if (!sources.length) return target;
   const source = sources.shift();
 
@@ -13,14 +13,14 @@ export default function mergeDeep (target, ...sources) {
     for (const key in source) {
       if (isObject(source[key])) {
         if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
+        deepAssign(target[key], source[key]);
       } else {
         Object.assign(target, { [key]: source[key] });
       }
     }
   }
 
-  return mergeDeep(target, ...sources);
+  return deepAssign(target, ...sources);
 }
 
 function isObject (item) {


### PR DESCRIPTION
- This is targeting `v4.8.0`
- Further reduces dist size