### PR TITLE
fix bug with listener not registered for cancel event on paypal

### DIFF
--- a/lib/recurly/paypal/index.js
+++ b/lib/recurly/paypal/index.js
@@ -18,7 +18,8 @@ export function factory (options) {
 const DEFERRED_EVENTS = [
   'ready',
   'token',
-  'error'
+  'error',
+  'cancel'
 ];
 
 /**


### PR DESCRIPTION
Currently listeners registered to the cancel event don't get called for paypal/braintree. This fix makes them get called.