### PR TITLE
Fix checkout deferred emitters

### DIFF
--- a/lib/recurly/pricing/checkout/attachment.js
+++ b/lib/recurly/pricing/checkout/attachment.js
@@ -80,10 +80,16 @@ export default class Attachment extends Emitter {
     const subscriptionGroups = groupBy(elems.all, el => dom.data(el, 'recurlySubscription'));
     delete subscriptionGroups.undefined;
 
-    // Removes all subscriptions and adjustments, as there is not a clean
-    // way to detect individual item removal without using observers
-    this.pricing.clearSubscriptions();
-    this.pricing.clearAdjustments();
+    // Remove abandoned subscriptions
+    this.pricing.items.subscriptions.forEach(sub => {
+      if (!subscriptionGroups[sub.id]) this.pricing.remove({ subscription: sub });
+    });
+
+    // Remove abandoned adjustments
+    const adjustmentElemIds = (elems.adjustment || []).map(el => dom.data(el, 'recurlyAdjustment'));
+    this.pricing.items.adjustments.forEach(adj => {
+      if (!~adjustmentElemIds.indexOf(adj.id)) this.pricing.remove({ adjustment: adj });
+    });
 
     // Builds a SubscriptionPricing instance per subscription element group
     Promise.all(Object.keys(subscriptionGroups).map(id => {

--- a/lib/recurly/pricing/checkout/attachment.js
+++ b/lib/recurly/pricing/checkout/attachment.js
@@ -207,7 +207,11 @@ export default class Attachment extends Emitter {
 
     if (elems.addon_price) {
       elems.addon_price.forEach(elem => {
-        const addonPrice = price.base.addons[dom.data(elem, 'recurlyAddon')];
+        const subscriptionId = dom.data(elem, 'recurlySubscription');
+        const subscription = subscriptionId && this.pricing.findSubscriptionById(subscriptionId);
+        if (!subscription) return;
+        if (!subscription.isValid) return;
+        const addonPrice = subscription.price.base.addons[dom.data(elem, 'recurlyAddon')];
         if (addonPrice) dom.value(elem, addonPrice);
       });
     }

--- a/lib/recurly/pricing/checkout/attachment.js
+++ b/lib/recurly/pricing/checkout/attachment.js
@@ -125,14 +125,14 @@ export default class Attachment extends Emitter {
       // Adjustments
       if (!elems.adjustment) return;
       return Promise.all(elems.adjustment.map(adjustmentElem => {
-        const code = dom.data(adjustmentElem, 'recurlyAdjustment');
+        const id = dom.data(adjustmentElem, 'recurlyAdjustment');
         const amount = dom.data(adjustmentElem, 'recurlyAdjustmentAmount');
         const quantity = dom.value(adjustmentElem);
         const currency = dom.data(adjustmentElem, 'recurlyAdjustmentCurrency');
         const taxCode = dom.data(adjustmentElem, 'recurlyAdjustmentTaxCode');
         const taxExempt = dom.data(adjustmentElem, 'recurlyAdjustmentTaxExempt')
 
-        return this.pricing.adjustment({ code, amount, quantity, currency, taxCode, taxExempt });
+        return this.pricing.adjustment({ id, amount, quantity, currency, taxCode, taxExempt });
       }));
     })
     .then(() => {

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -169,7 +169,7 @@ export default class Calculations {
     this.validAdjustments.forEach(adjustment => {
       const { amount: unitAmount, quantity, id } = adjustment;
       const amount = unitAmount * quantity;
-      const item = { type: 'adjustment', id, amount, quantity, unitAmount, taxes: 0 };
+      const item = { type: 'adjustment', id, amount, quantity, unitAmount };
 
       this.price.now.adjustments += amount;
       this._itemizedSets.now.adjustments.push(item);

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -167,9 +167,9 @@ export default class Calculations {
     this._itemizedSets.now.adjustments = [];
 
     this.validAdjustments.forEach(adjustment => {
-      const { amount: unitAmount, quantity, code } = adjustment;
+      const { amount: unitAmount, quantity, id } = adjustment;
       const amount = unitAmount * quantity;
-      const item = { type: 'adjustment', code, amount, quantity, unitAmount };
+      const item = { type: 'adjustment', id, amount, quantity, unitAmount, taxes: 0 };
 
       this.price.now.adjustments += amount;
       this._itemizedSets.now.adjustments.push(item);

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -162,8 +162,14 @@ export default class CheckoutPricing extends Pricing {
 
       if (!this.items.currency) this.currency(subscription.items.currency);
 
+      const emitSubscriptionSetter = name => {
+        return item => this.emit(`set.${name}`, { subscription: { id: subscription.id }, [name]: item });
+      };
+
       const addSubscription = () => {
         subscription.on('change:external', () => this.reprice());
+        subscription.on('set.plan', emitSubscriptionSetter('plan'));
+        subscription.on('set.addon', emitSubscriptionSetter('addon'));
         this.items.subscriptions.push(new EmbeddedSubscriptionPricing(subscription, this));
         debug('set.subscription');
         this.emit('set.subscription', subscription);

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -360,17 +360,33 @@ export default class CheckoutPricing extends Pricing {
   }
 
   /**
-   * Clears all subscriptions
+   * Adds handlers to remove subscriptions and adjustments
+   *
+   * @param {Object} options
+   * @param {Object} options[item] Must contain an id property. The key name
+   *                               corresponds to the item type to be removed (ex: 'subscription')
    */
-  clearSubscriptions () {
-    this.items.subscriptions = [];
+  remove (options) {
+    return new PricingPromise((resolve, reject) => {
+      // Expects SubscriptionPricing or EmbeddedSubscriptionPricing
+      if (options.subscription) {
+        this.removeFromSet('subscriptions', options.subscription);
+      } else if (options.adjustment) {
+        this.removeFromSet('adjustments', options.adjustment);
+      } else {
+        super.remove(options);
+      }
+    });
   }
 
   /**
-   * Clears all adjustments
+   * Removes a set item (subscription or adjustment)
+   *
+   * @param  {String} name         item name (ex: 'subscription', 'adjustment')
+   * @param  {Object} itemToRemove item to remove. Must have an id property
    */
-  clearAdjustments () {
-    this.items.adjustments = [];
+  removeFromSet (name, itemToRemove) {
+    this.items[name] = this.items[name].filter(item => item.id !== itemToRemove.id);
   }
 
   /**

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -191,16 +191,16 @@ export default class CheckoutPricing extends Pricing {
    * @param {Object}  adjustment
    * @param {Number}  adjustment.amount in unit price (1.0 for USD, etc)
    * @param {Number}  [adjustment.quantity=1] number of units
-   * @param {String}  [adjustment.code=uuid()] unique identifier
+   * @param {String}  [adjustment.id=uuid()] unique identifier
    * @param {String}  [adjustment.currency=this.items.currency] currency code
    * @param {Boolean} [adjustment.taxExempt=false] whether this adjustment is tax exempt
    * @param {String}  [adjustment.taxCode] taxation code
    * @return {PricingPromise}
    * @public
    */
-  adjustment ({ amount, quantity, code = uuid(), currency, taxExempt, taxCode }) {
+  adjustment ({ amount, quantity, id = uuid(), currency, taxExempt, taxCode }) {
     return new PricingPromise((resolve, reject) => {
-      let existingAdjustment = find(this.items.adjustments, a => a.code === code);
+      let existingAdjustment = find(this.items.adjustments, a => a.id === id);
       let validateAmount = true;
 
       if (existingAdjustment && typeof amount === 'undefined') {
@@ -233,7 +233,7 @@ export default class CheckoutPricing extends Pricing {
         currency = currency || this.items.currency;
         taxExempt = !!taxExempt;
 
-        adjustment = { amount, quantity, code, currency, taxExempt, taxCode };
+        adjustment = { amount, quantity, id, currency, taxExempt, taxCode };
 
         this.items.adjustments.push(adjustment);
       }

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -105,18 +105,20 @@ export default class EmbeddedSubscriptionPricing {
         }
 
         plan.quantity = quantity;
-        this.subscription.items.plan = plan;
+
+        const addPlan = () => {
+          this.subscription.items.plan = plan;
+          this.subscription.emit('set.plan', plan);
+          return plan;
+        }
 
         // Update checkout currency, which will update the subscription currency
-        if (this.checkout.currencyCode in plan.price) return resolve();
+        if (this.checkout.currencyCode in plan.price) return resolve(addPlan());
 
         // update currencies on checkout, which will propagate the
         // change to the subscriptions
         this.checkout.resolveCurrency(Object.keys(plan.price))
-          .then(() => {
-            this.subscription.emit('set.plan', plan);
-            resolve(plan);
-          })
+          .then(() => resolve(addPlan()))
           .catch(err => reject(err));
       });
     }, this.subscription).nodeify(done);

--- a/lib/recurly/pricing/subscription/embedded.js
+++ b/lib/recurly/pricing/subscription/embedded.js
@@ -105,21 +105,24 @@ export default class EmbeddedSubscriptionPricing {
         }
 
         plan.quantity = quantity;
+        this.subscription.items.plan = plan;
 
-        const addPlan = () => {
-          this.subscription.items.plan = plan;
+        const finish = () => {
           this.subscription.emit('set.plan', plan);
-          return plan;
+          resolve(plan);
         }
 
-        // Update checkout currency, which will update the subscription currency
-        if (this.checkout.currencyCode in plan.price) return resolve(addPlan());
-
-        // update currencies on checkout, which will propagate the
-        // change to the subscriptions
-        this.checkout.resolveCurrency(Object.keys(plan.price))
-          .then(() => resolve(addPlan()))
-          .catch(err => reject(err));
+        if (this.checkout.currencyCode in plan.price) {
+          finish();
+        } else {
+          // update currencies on checkout, which will propagate the
+          // change to the subscriptions
+          try {
+            this.checkout.resolveCurrency(Object.keys(plan.price)).then(finish);
+          } catch (e) {
+            reject(err);
+          }
+        }
       });
     }, this.subscription).nodeify(done);
   }

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -298,10 +298,10 @@ describe('CheckoutPricing', function () {
 
     describe('updating an existing adjustment', () => {
       beforeEach(function () {
-        this.adjustmentExampleOne = { amount: 20, code: 'adjustment-0' };
+        this.adjustmentExampleOne = { amount: 20, id: 'adjustment-0' };
         this.adjustmentExampleTwo = {
           amount: 10,
-          code: 'adjustment-1',
+          id: 'adjustment-1',
           currency: 'EUR',
           quantity: 0,
           taxExempt: true,
@@ -319,7 +319,7 @@ describe('CheckoutPricing', function () {
         let secondAdjustment = this.pricing.items.adjustments[1]
 
         assert.equal(firstAdjustment.amount, 20);
-        assert.equal(firstAdjustment.code, 'adjustment-0');
+        assert.equal(firstAdjustment.id, 'adjustment-0');
         assert.equal(firstAdjustment.quantity, 1);
         assert.equal(firstAdjustment.currency, 'USD');
         assert.equal(firstAdjustment.taxExempt, false);
@@ -327,10 +327,10 @@ describe('CheckoutPricing', function () {
         assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
 
         this.pricing
-          .adjustment({ code: 'adjustment-0' })
+          .adjustment({ id: 'adjustment-0' })
           .then(() => {
             assert.equal(firstAdjustment.amount, 20);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 1);
             assert.equal(firstAdjustment.currency, 'USD');
             assert.equal(firstAdjustment.taxExempt, false);
@@ -338,10 +338,10 @@ describe('CheckoutPricing', function () {
             assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
             part();
           })
-          .adjustment({ code: 'adjustment-0', amount: 400 })
+          .adjustment({ id: 'adjustment-0', amount: 400 })
           .then(() => {
             assert.equal(firstAdjustment.amount, 400);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 1);
             assert.equal(firstAdjustment.currency, 'USD');
             assert.equal(firstAdjustment.taxExempt, false);
@@ -349,10 +349,10 @@ describe('CheckoutPricing', function () {
             assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
             part();
           })
-          .adjustment({ code: 'adjustment-0', quantity: 0 })
+          .adjustment({ id: 'adjustment-0', quantity: 0 })
           .then(() => {
             assert.equal(firstAdjustment.amount, 400);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 0);
             assert.equal(firstAdjustment.currency, 'USD');
             assert.equal(firstAdjustment.taxExempt, false);
@@ -360,10 +360,10 @@ describe('CheckoutPricing', function () {
             assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
             part();
           })
-          .adjustment({ code: 'adjustment-0', currency: 'GBP' })
+          .adjustment({ id: 'adjustment-0', currency: 'GBP' })
           .then(() => {
             assert.equal(firstAdjustment.amount, 400);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 0);
             assert.equal(firstAdjustment.currency, 'GBP');
             assert.equal(firstAdjustment.taxExempt, false);
@@ -371,10 +371,10 @@ describe('CheckoutPricing', function () {
             assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
             part();
           })
-          .adjustment({ code: 'adjustment-0', taxExempt: true })
+          .adjustment({ id: 'adjustment-0', taxExempt: true })
           .then(() => {
             assert.equal(firstAdjustment.amount, 400);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 0);
             assert.equal(firstAdjustment.currency, 'GBP');
             assert.equal(firstAdjustment.taxExempt, true);
@@ -382,10 +382,10 @@ describe('CheckoutPricing', function () {
             assert.deepEqual(secondAdjustment, this.adjustmentExampleTwo);
             part();
           })
-          .adjustment({ code: 'adjustment-0', taxCode: 0 })
+          .adjustment({ id: 'adjustment-0', taxCode: 0 })
           .then(() => {
             assert.equal(firstAdjustment.amount, 400);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 0);
             assert.equal(firstAdjustment.currency, 'GBP');
             assert.equal(firstAdjustment.taxExempt, true);
@@ -394,7 +394,7 @@ describe('CheckoutPricing', function () {
             part();
           })
           .adjustment({
-            code: 'adjustment-0',
+            id: 'adjustment-0',
             amount: 25,
             currency: 'USD',
             quantity: 10,
@@ -403,7 +403,7 @@ describe('CheckoutPricing', function () {
           })
           .then(() => {
             assert.equal(firstAdjustment.amount, 25);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 10);
             assert.equal(firstAdjustment.currency, 'USD');
             assert.equal(firstAdjustment.taxExempt, true);
@@ -412,20 +412,20 @@ describe('CheckoutPricing', function () {
             part();
           })
           .adjustment({
-            code: 'adjustment-1',
+            id: 'adjustment-1',
             amount: 0,
             quantity: 1,
           })
           .done(price => {
             assert.equal(firstAdjustment.amount, 25);
-            assert.equal(firstAdjustment.code, 'adjustment-0');
+            assert.equal(firstAdjustment.id, 'adjustment-0');
             assert.equal(firstAdjustment.quantity, 10);
             assert.equal(firstAdjustment.currency, 'USD');
             assert.equal(firstAdjustment.taxExempt, true);
             assert.equal(firstAdjustment.taxCode, 'tax-code-1');
 
             assert.equal(secondAdjustment.amount, 0);
-            assert.equal(secondAdjustment.code, 'adjustment-1');
+            assert.equal(secondAdjustment.id, 'adjustment-1');
             assert.equal(secondAdjustment.quantity, 1);
             assert.equal(secondAdjustment.currency, 'EUR');
             assert.equal(secondAdjustment.taxExempt, true);


### PR DESCRIPTION
- Fixes propagation of subscription events like `set.plan` to their checkout
- Simplifies `CheckoutPricing/Attachment` subscription and adjustment handling, precisely removing and updating existing items in-place
- Updates adjustment data model to use `id` instead of `code` to make it compatible with pricing item expectations
- Fixes `CheckoutPricing/Attachment` `addon_price` output element assignment