### PR TITLE
Fixes vestigial coupons on Checkout Calculations

### DIFF
--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -360,7 +360,7 @@ export default class CheckoutPricing extends Pricing {
   }
 
   /**
-   * Adds handlers to remove subscriptions and adjustments
+   * Adds handlers to remove subscriptions, adjustments, and coupons
    *
    * @param {Object} options
    * @param {Object} options[item] Must contain an id property. The key name
@@ -374,7 +374,13 @@ export default class CheckoutPricing extends Pricing {
       } else if (options.adjustment) {
         this.removeFromSet('adjustments', options.adjustment);
       } else {
-        super.remove(options);
+        if (options.coupon) {
+          // Remove the coupon from embedded subscriptions
+          Promise.all(this.validSubscriptions.map(sub => sub.coupon().reprice({ internal: true })))
+            .then(() => resolve(super.remove(options)));
+        } else {
+          resolve(super.remove(options));
+        }
       }
     });
   }


### PR DESCRIPTION
- Clears coupons from subscriptions on checkout coupon removal
- When a free trial coupon exists on a checkout, it is applied to the most valuable subscription. Removing that coupon from the checkout would not immediately remove it from the subscription, resulting in checkout calculations based on the prior free trial coupon.