### PR TITLE
Fix checkout coupon currency safety

### DIFF
--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -384,8 +384,10 @@ export default class Calculations {
         discountNext = roundForDiscount(discountableNext * coupon.discount.rate);
       } else if (coupon.discount.amount) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
-        discountNow = Math.min(discountableNow, coupon.discount.amount[this.items.currency]);
-        discountNext = Math.min(discountableNext, coupon.discount.amount[this.items.currency]);
+        // Falls back to zero if the coupon does not support the checkout currency
+        const discountAmount = coupon.discount.amount[this.items.currency] || 0;
+        discountNow = Math.min(discountableNow, discountAmount);
+        discountNext = Math.min(discountableNext, discountAmount);
       }
     }
     return { discountNow, discountNext };

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -259,27 +259,29 @@ export default class CheckoutPricing extends Pricing {
       this.emit('unset.coupon');
     };
 
-    return new PricingPromise((resolve, reject) => {
-      if (this.items.coupon) this.remove({ coupon: this.items.coupon.code });
-
-      // A blank coupon is handled as ok
-      if (!couponCode) {
-        unset();
-        return resolve();
-      }
-
-      this.recurly.coupon({ plans: this.subscriptionPlanCodes, coupon: couponCode }, (err, coupon) => {
-        if (err && err.code === 'not-found') unset();
-        if (err) {
-          return this.error(err, reject, 'coupon');
-        } else {
-          debug('set.coupon');
-          this.items.coupon = coupon;
-          this.emit('set.coupon', coupon);
-          resolve(coupon);
+    return new PricingPromise(resolve => resolve(), this)
+      .then(() => {
+        if (this.items.coupon) return this.remove({ coupon: this.items.coupon.code });
+      })
+      .then(() => new PricingPromise((resolve, reject) => {
+        // A blank coupon is handled as ok
+        if (!couponCode) {
+          unset();
+          return resolve();
         }
-      });
-    }, this);
+
+        this.recurly.coupon({ plans: this.subscriptionPlanCodes, coupon: couponCode }, (err, coupon) => {
+          if (err && err.code === 'not-found') unset();
+          if (err) {
+            return this.error(err, reject, 'coupon');
+          } else {
+            debug('set.coupon');
+            this.items.coupon = coupon;
+            this.emit('set.coupon', coupon);
+            resolve(coupon);
+          }
+        });
+      }));
   }
 
   /**
@@ -377,9 +379,9 @@ export default class CheckoutPricing extends Pricing {
         if (options.coupon) {
           // Remove the coupon from embedded subscriptions
           Promise.all(this.validSubscriptions.map(sub => sub.coupon().reprice({ internal: true })))
-            .then(() => resolve(super.remove(options)));
+            .then(() => super.remove(options).then(resolve, reject));
         } else {
-          resolve(super.remove(options));
+          super.remove(options).then(resolve, reject);
         }
       }
     });

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -115,6 +115,7 @@ export class Pricing extends Emitter {
           reason: 'does not exist on this pricing instance.'
         }), reject);
       }
+      resolve();
     }, this).nodeify(done);
   }
 

--- a/test/server/fixtures/coupons/coop-fixed-all-500-eur.json
+++ b/test/server/fixtures/coupons/coop-fixed-all-500-eur.json
@@ -1,0 +1,16 @@
+{
+  "code": "coop-fixed-all-500-eur",
+  "name": "Test coupon: EUR 500 off all charges",
+  "discount": {
+    "type": "dollars",
+    "amount": {
+      "EUR": 500
+    }
+  },
+  "plans": [],
+  "single_use": false,
+  "applies_to_non_plan_charges": true,
+  "applies_to_plans": true,
+  "applies_to_all_plans": true,
+  "redemption_resource": "account"
+}


### PR DESCRIPTION
- Fixes Pricing.remove async completion
- Ensures removal has completed before proceeding to unset and retrieval of new coupon
- If a coupon does not support the checkout currency, it will not attempt to discount the checkout