### PR TITLE
Adds displayIcon field configuration option pass-through

### DIFF
--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -158,11 +158,12 @@ export class HostedFields extends Emitter {
     if (!fields[type]) return;
     return {
       type,
-      selector: fields[type].selector,
+      displayIcon: fields[type].displayIcon,
       format: fields[type].format || fields.all.format,
       inputType: fields[type].inputType,
-      style: deepAssign({}, fields.all.style, fields[type].style),
-      recurly: this.config.recurly
+      recurly: this.config.recurly,
+      selector: fields[type].selector,
+      style: deepAssign({}, fields.all.style, fields[type].style)
     };
   }
 


### PR DESCRIPTION
- Adds a new `displayIcon` configuration value, which will inform a card field to not display its integrated card brand icon

#### Example

```js
recurly.configure({
  // ...
  fields: {
    card: {
      displayIcon: false
    }
  }
  // ...
});
```