### PR TITLE
chore: remove eval from minified file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,9 @@ var path = require('path');
 var minify = ~process.argv.indexOf('-p');
 
 module.exports = {
+  node: {
+    global: false,
+  },
   entry: './index',
   output: {
     path: path.join(__dirname, 'build'),


### PR DESCRIPTION
We wish to use `recurly.js` on a site which has a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in place that does not permit `unsafe-eval` for `script-src` resources.

> 'unsafe-eval'
    Allows the use of eval() and similar methods for creating code from strings. You must include the single quotes.

I believe that this is being introduced to your compiled codebase by Webpack. This thread has some further insight into people's experience here [#5627 Calling Function or eval should be eliminated as a security measure and would cause the application execution to be halted if the document CSP header has script-src 'self'; ](https://github.com/webpack/webpack/issues/5627)

