### PR TITLE
fix: switch to using window over global

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -63,9 +63,9 @@ class ApplePay extends Emitter {
     this.once('ready', () => this._ready = true);
 
     // Detect whether Apple Pay is available
-    if (!global.ApplePaySession) {
+    if (!window.ApplePaySession) {
       this.initError = this.error('apple-pay-not-supported');
-    } else if (!global.ApplePaySession.canMakePayments()) {
+    } else if (!window.ApplePaySession.canMakePayments()) {
       this.initError = this.error('apple-pay-not-available');
     }
 
@@ -85,7 +85,7 @@ class ApplePay extends Emitter {
 
     this.addAuthorizationLineItem();
 
-    let session = new global.ApplePaySession(APPLE_PAY_API_VERSION, {
+    let session = new window.ApplePaySession(APPLE_PAY_API_VERSION, {
       countryCode: this.config.country,
       currencyCode: this.config.currency,
       supportedNetworks: this.config.supportedNetworks,

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -126,7 +126,7 @@ export class Bus extends Emitter {
  * @return {Boolean}
  */
 function origin (url) {
-  let parser = global.document.createElement('a');
+  let parser = window.document.createElement('a');
   parser.href = url;
   return `${parser.protocol}//${parser.host}`;
 }

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -48,7 +48,7 @@ class Frame extends Emitter {
     payload.key = this.recurly.config.publicKey;
 
     this.once(payload.event, res => {
-      if (this.relay) global.document.body.removeChild(this.relay);
+      if (this.relay) window.document.body.removeChild(this.relay);
       if (res.error) this.emit('error', res.error);
       else this.emit('done', res)
     });
@@ -70,7 +70,7 @@ class Frame extends Emitter {
       relay.name = `recurly-relay-${this.recurly.id}-${this.id}`;
       relay.style.display = 'none';
       relay.onload = () => this.create();
-      global.document.body.appendChild(relay);
+      window.document.body.appendChild(relay);
       this.relay = relay;
       debug('Created relay', relay);
     } else {
@@ -80,7 +80,7 @@ class Frame extends Emitter {
 
   create () {
     debug('opening frame window', this.url, this.name, this.attributes);
-    global.open(this.url, this.name, this.attributes);
+    window.open(this.url, this.name, this.attributes);
   }
 
   get attributes () {
@@ -94,15 +94,15 @@ class Frame extends Emitter {
   }
 
   get top () {
-    const outerHeight = global.outerHeight || global.document.documentElement.clientHeight;
-    const outerTop = global.screenY === null ? global.screenTop : global.screenY;
+    const outerHeight = window.outerHeight || window.document.documentElement.clientHeight;
+    const outerTop = window.screenY === null ? window.screenTop : window.screenY;
 
     return center(outerHeight, this.height, outerTop);
   }
 
   get left () {
-    const outerWidth = global.outerWidth || global.document.documentElement.clientWidth;
-    const outerLeft = global.screenX === null ? global.screenLeft : global.screenX;
+    const outerWidth = window.outerWidth || window.document.documentElement.clientWidth;
+    const outerLeft = window.screenX === null ? window.screenLeft : window.screenX;
 
     return center(outerWidth, this.width, outerLeft);
   }

--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -94,7 +94,7 @@ export class HostedField extends Emitter {
   // Private
   configure (options) {
     options = clone(options);
-    if (!this.target) this.target = dom.element(global.document.querySelector(options.selector));
+    if (!this.target) this.target = dom.element(window.document.querySelector(options.selector));
     if (!this.target) {
       const { type, selector } = options;
       throw errors('missing-hosted-field-target', { type, selector });
@@ -136,7 +136,7 @@ export class HostedField extends Emitter {
   bindDeferredFocus () {
     this.container.addEventListener('click', this.focus);
     if (!this.target.id) return;
-    const labels = global.document.querySelectorAll(`label[for=${this.target.id}]`);
+    const labels = window.document.querySelectorAll(`label[for=${this.target.id}]`);
     [].slice.apply(labels).forEach(label => {
       label.addEventListener('click', this.focus);
     });

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -137,7 +137,7 @@ export class HostedFields extends Emitter {
   }
 
   tabbableItems () {
-    return tabbable(global.document.body);
+    return tabbable(window.document.body);
   }
 
   update (body) {

--- a/lib/recurly/paypal/strategy/braintree.js
+++ b/lib/recurly/paypal/strategy/braintree.js
@@ -59,7 +59,7 @@ export class BraintreeStrategy extends PayPalStrategy {
     debug('Initializing Braintree client');
 
     const authorization = this.config.clientAuthorization;
-    const braintree = global.braintree;
+    const braintree = window.braintree;
 
     braintree.client.create({ authorization }, (error, client) => {
       if (error) return this.fail('paypal-braintree-api-error', { cause: error });
@@ -107,7 +107,7 @@ export class BraintreeStrategy extends PayPalStrategy {
   }
 
   braintreeClientAvailable (module) {
-    const bt = global.braintree;
+    const bt = window.braintree;
     return bt && bt.client && bt.client.VERSION === BRAINTREE_CLIENT_VERSION && (module ? module in bt : true);
   }
 }

--- a/lib/recurly/request.js
+++ b/lib/recurly/request.js
@@ -11,8 +11,8 @@ const debug = require('debug')('recurly:Request');
  * XHR/XDM Reference, according to browser environment
  */
 const XHR = (() => {
-  const XHR = global.XMLHttpRequest;
-  const XDM = global.XDomainRequest;
+  const XHR = window.XMLHttpRequest;
+  const XDM = window.XDomainRequest;
   if (XHR && 'withCredentials' in new XHR) return XHR;
   if (XDM) return XDM;
 })();

--- a/lib/util/dom.js
+++ b/lib/util/dom.js
@@ -199,7 +199,7 @@ function createHiddenInput (attributes = {}) {
     inputType = attributes.type;
     delete attributes.type;
   }
-  let hidden = global.document.createElement(inputType);
+  let hidden = window.document.createElement(inputType);
   if (!('type' in attributes)) attributes.type = 'text';
   if (!('style' in attributes)) attributes.style = 'position: absolute; top: 0px; left: -1000px; opacity: 0;';
 

--- a/test/apple-pay.test.js
+++ b/test/apple-pay.test.js
@@ -44,15 +44,15 @@ apiTest(function (requestMethod) {
 
     beforeEach(function () {
       this.recurly = initRecurly({ cors: requestMethod === 'cors' });
-      global.ApplePaySession = ApplePaySessionStub;
+      window.ApplePaySession = ApplePaySessionStub;
     });
 
-    afterEach(() => delete global.ApplePaySession);
+    afterEach(() => delete window.ApplePaySession);
 
     describe('Constructor', function () {
       describe('when Apple Pay is not supported', function () {
         beforeEach(function () {
-          delete global.ApplePaySession;
+          delete window.ApplePaySession;
           this.applePay = this.recurly.ApplePay(validOpts);
         });
 

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -8,7 +8,7 @@ import {fixture} from './support/fixtures';
 import {Recurly} from '../lib/recurly';
 
 describe('Recurly.configure', function () {
-  let api = `${global.location.protocol}//${global.location.host}/api`;
+  let api = `${window.location.protocol}//${window.location.host}/api`;
 
   beforeEach(function () {
     if (this.currentTest.ctx.fixture) fixture(this.currentTest.ctx.fixture);

--- a/test/paypal/paypal.test.js
+++ b/test/paypal/paypal.test.js
@@ -33,7 +33,7 @@ apiTest(function (requestMethod) {
 
       describe('when the braintree client fails to initialize', function () {
         beforeEach(function () {
-          global.braintree.client.create = (opt, cb) => cb({ error: 'test' });
+          window.braintree.client.create = (opt, cb) => cb({ error: 'test' });
           sinon.spy(this.recurly, 'Frame');
           this.paypal = this.recurly.PayPal(validOpts);
         });

--- a/test/paypal/strategy/direct.test.js
+++ b/test/paypal/strategy/direct.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import {initRecurly} from '../../support/helpers';
 
-const sinon = global.sinon;
+const sinon = window.sinon;
 
 describe('DirectStrategy', function () {
   const displayName = 'test';

--- a/test/pricing/checkout/attachment.test.js
+++ b/test/pricing/checkout/attachment.test.js
@@ -3,7 +3,7 @@ import {applyFixtures} from '../../support/fixtures';
 import {initRecurly} from '../../support/helpers';
 import CheckoutPricingAttachment from '../../../lib/recurly/pricing/checkout/attachment'
 
-const container = () => global.document.querySelector('#test-pricing');
+const container = () => window.document.querySelector('#test-pricing');
 
 describe('CheckoutPricing#attach', function () {
   beforeEach(function (done) {

--- a/test/pricing/subscription/attachment.test.js
+++ b/test/pricing/subscription/attachment.test.js
@@ -3,7 +3,7 @@ import {applyFixtures} from '../../support/fixtures';
 import {initRecurly} from '../../support/helpers';
 import PricingAttachment from '../../../lib/recurly/pricing/subscription/attachment'
 
-const container = () => global.document.querySelector('#test-pricing');
+const container = () => window.document.querySelector('#test-pricing');
 
 describe('Recurly.Pricing.attach', function () {
   beforeEach(function (done) {

--- a/test/recurly.test.js
+++ b/test/recurly.test.js
@@ -10,8 +10,8 @@ describe('Recurly', () => {
 
   it('should have a version', () => assert(typeof recurly.version === 'string'));
   it('should be an event emitter', () => assert(recurly.on && recurly.emit));
-  it('should be exposed as a global singleton', () => {
-    assert(global.recurly instanceof window.recurly.Recurly);
+  it('should be exposed as a window. singleton', () => {
+    assert(window.recurly instanceof window.recurly.Recurly);
   });
 
   describe('Pricing factories', () => {

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -15,7 +15,7 @@ export function initRecurly (recurly, opts) {
   }
   recurly.configure(merge({
     publicKey: 'test',
-    api: `${global.location.protocol}//${global.location.host}/api`
+    api: `${window.location.protocol}//${window.location.host}/api`
   }, opts));
   return recurly;
 }
@@ -30,11 +30,11 @@ export function domTest (suite) {
 }
 
 export function testBed () {
-  let el = global.document.getElementById('dom-testbed');
+  let el = window.document.getElementById('dom-testbed');
   if (!el) {
-    el = global.document.createElement('div')
+    el = window.document.createElement('div')
     el.id = 'dom-testbed';
-    global.document.body.appendChild(el);
+    window.document.body.appendChild(el);
   }
   return el;
 }
@@ -46,7 +46,7 @@ export function nextTick (cb) {
 export function braintreeStub () {
   beforeEach(() => {
     const create = (opt, cb) => cb(null, {});
-    global.braintree = {
+    window.braintree = {
       client: {
         VERSION: BRAINTREE_CLIENT_VERSION,
         create
@@ -56,5 +56,5 @@ export function braintreeStub () {
     };
   });
 
-  afterEach(() => delete global.braintree);
+  afterEach(() => delete window.braintree);
 }

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -379,7 +379,7 @@ apiTest(requestMethod => {
     // For each example, updates corresponding hosted fields and returns all others
     function plainObjectBuilder (example) {
       example = clone(example);
-      const form = global.document.querySelector('#test-form');
+      const form = window.document.querySelector('#test-form');
       each(example, (val, key) => {
         let el = form.querySelector(`[data-recurly=${key}]`);
         if (el instanceof HTMLDivElement) {
@@ -392,7 +392,7 @@ apiTest(requestMethod => {
 
     // For each example, updates corresponding input filds or hosted fields
     function formBuilder (example) {
-      const form = global.document.querySelector('#test-form');
+      const form = window.document.querySelector('#test-form');
       each(example, (val, key) => {
         let el = form.querySelector(`[data-recurly=${key}]`);
         if (el instanceof HTMLDivElement) {


### PR DESCRIPTION
As mentioned in #455 it would be good to remove use of eval. To facilitate that change we need to remove use of `global` within the library and instead use `window`