### PR TITLE
Fix pricing calculation for multiple addons

### DIFF
--- a/lib/recurly/pricing/subscription/attachment.js
+++ b/lib/recurly/pricing/subscription/attachment.js
@@ -76,15 +76,15 @@ export default class Attachment extends Emitter {
 
     if (updateAddon) {
       pricing = pricing.then(() => {
-        elems.addon.forEach(elem => {
+        return Promise.all(elems.addon.map(elem => {
           const plan = this.pricing.items.plan;
           const code = dom.data(elem, 'recurlyAddon');
           const quantity = dom.value(elem);
 
           if (plan.addons && find(plan.addons, { code })) {
-            pricing = pricing.addon(code, { quantity });
+            return this.pricing.addon(code, { quantity });
           }
-        });
+        }));
       });
     }
 


### PR DESCRIPTION
Fixes a problem where only the first addon is calculated when the pricing module is attached to a form which already has multiple addon elements