### PR TITLE
Allow specifying requiredShippingContactFields in Apple Pay

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -91,6 +91,7 @@ class ApplePay extends Emitter {
       supportedNetworks: this.config.supportedNetworks,
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
+      requiredShippingContactFields: this.config.requiredShippingContactFields,
       total: this.totalLineItem
     });
 
@@ -199,6 +200,7 @@ class ApplePay extends Emitter {
 
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
+      this.config.requiredShippingContactFields = options.requiredShippingContactFields || [];
 
       this.emit('ready');
     }
@@ -301,6 +303,9 @@ class ApplePay extends Emitter {
   onShippingContactSelected (event) {
     const status = this.session.STATUS_SUCCESS;
     const newShippingMethods = [];
+
+    this.emit('shippingContactSelected', event);
+    
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
   }
 
@@ -345,6 +350,7 @@ class ApplePay extends Emitter {
         debug('Token received', token);
 
         this.session.completePayment(this.session.STATUS_SUCCESS);
+        this.emit('authorized', event);
         this.emit('token', token);
       }
     });


### PR DESCRIPTION
User can (optionally) request additional fields from Apple Pay, such as
email, shipping address, etc, and process the responses on new emitters
from `onShippingContactSelected` and `onPaymentAuthorized`.

Example:


Specify `requiredShippingContactFields` if desired:

```
var applePay = recurly.ApplePay({
  country: 'US',
  currency: 'USD',
  label: "Surface",
  pricing: pricing,
  requiredShippingContactFields: ['email', 'name', 'postalAddress']
});
```


Listen for shipping contact changes, and authorized payments, to use the passed data from Apple Pay:

```
applePay.on('shippingContactSelected', function (event) {
    var shippingContact = event.shippingContact;

    console.log(shippingContact);
});

applePay.on('authorized', function (authorized) {
  var payment = authorized.payment;
  var billingContact = payment.billingContact;
  var shippingContact = payment.shippingContact;

  console.log("Shipping Contact Email Address: " + shippingContact.emailAddress);
});
```
