### PR TITLE
Fixes issue where tax exemption results in negative taxes

### DIFF
--- a/lib/util/tax-ceil.js
+++ b/lib/util/tax-ceil.js
@@ -2,10 +2,13 @@
  * Ceilings the second decimal of a number without risk of
  * floating point math errors
  *
+ * - returns zero if the result is negative
+ *
  * @param {Number} number
  * @return {Number}
  */
 
 export default function taxCeil (number) {
+  number = Math.max(number, 0);
   return +(Math.ceil(number + 'e+2') + 'e-2');
 }

--- a/test/server/fixtures/coupons/coop-fixed-all-5.json
+++ b/test/server/fixtures/coupons/coop-fixed-all-5.json
@@ -1,0 +1,21 @@
+{
+  "code": "coop-fixed-all-5",
+  "name": "Test coupon: $5 off all charges",
+  "discount": {
+    "type": "dollars",
+    "amount":
+      {
+        "USD": 5.0
+      }
+  },
+  "single_use": false,
+  "applies_for_months": null,
+  "duration": "forever",
+  "temporal_unit": null,
+  "temporal_amount": null,
+  "plans": [],
+  "applies_to_non_plan_charges": true,
+  "applies_to_plans": true,
+  "applies_to_all_plans": true,
+  "redemption_resource": "account"
+}


### PR DESCRIPTION
- Occurs if a merchant sets all items on a checkout to be tax exempt
- If a blanket amount discount is applied, then taxes will be subtracted according to the discount amount. Since discounts are not exampt-able, a negative tax amount would occur