### PR TITLE
Catches non-critical worker init errors and reports them via debug

### DIFF
--- a/lib/recurly/reporter.js
+++ b/lib/recurly/reporter.js
@@ -14,7 +14,11 @@ export class Reporter {
     this.recurly = recurly;
     if (!this.shouldDispatch) return;
     this.worker = new IntervalWorker({ perform: this.deliver.bind(this) });
-    this.worker.start();
+    try {
+      this.worker.start();
+    } catch (err) {
+      debug('Error starting worker', err);
+    }
   }
 
   /**


### PR DESCRIPTION
- This prevents a console error and init halt if an interval cannot be set for a worker in certain environments