### PR TITLE
Fix - TypeError: Cannot read property 'brand' of undefined

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -319,7 +319,7 @@ export class Recurly extends Emitter {
       this.on(`hostedField:${eventName}`, ({ type }) => {
         const state = this.hostedFields.state[type];
         let meta = pick(state, ['valid', 'empty']);
-        if (state.brand) meta.brand = state.brand;
+        if (state && state.brand) meta.brand = state.brand;
         this.report(`hosted-field:${eventName}`, meta);
       });
     });


### PR DESCRIPTION
## Issue

We are seeing the 100k errors in production since Sept 27.
```
TypeError: Cannot read property 'brand' of undefined
1
File https://js.recurly.com/v4/recurly.js line 1 col 41317 in t.<anonymous>
2
File https://js.recurly.com/v4/recurly.js line 1 col 10701 in t.n.emit
3
File https://js.recurly.com/v4/recurly.js line 7 col 59595 in [anonymous]
4
File https://js.recurly.com/v4/recurly.js line 7 col 59477 in t.value
5
File https://js.recurly.com/v4/recurly.js line 7 col 58819 in t.value
```

## Change

The following change checks that `state` is truthy before accessing `brand`