### PR TITLE
Fixes coupon resolving when switching subscription plans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 'node'
+  - 10
 before_install:
   - bash .travis-install-phantom.sh
 cache:

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -106,7 +106,7 @@ export class Pricing extends Emitter {
    */
   remove (opts, done) {
     let item;
-    this.debug('remove');
+    this.debug('remove', opts);
 
     return new PricingPromise((resolve, reject) => {
       let prop = Object.keys(opts)[0];

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -211,19 +211,22 @@ export default class SubscriptionPricing extends Pricing {
    * @public
    */
   coupon (newCoupon, done) {
+    // If the new coupon matches the current one, we just need to ensure it
+    // still applies to the current plan
     if (~this.couponCodes.indexOf(newCoupon)) {
-      return new PricingPromise(resolve => resolve(clone(this.items.coupon)), this);
+      return new PricingPromise((resolve, reject) => {
+        if (!this.couponIsValidForSubscription(this.items.coupon)) {
+          this.removeCurrentCoupon();
+          return this.error('invalid-coupon-for-subscription', reject, 'coupon');
+        }
+        resolve(clone(this.items.coupon));
+      }, this);
     }
 
     return new PricingPromise((resolve, reject) => {
       if (!this.items.plan) return this.error(errors('missing-plan'), reject, 'coupon');
 
-      if (this.items.coupon) {
-        const priorCoupon = clone(this.items.coupon);
-        debug('unset.coupon');
-        this.remove({ coupon: priorCoupon.code })
-          .then(() => this.emit('unset.coupon', priorCoupon));
-      }
+      if (this.items.coupon) this.removeCurrentCoupon();
 
       // A blank coupon is handled as ok
       if (!newCoupon) return resolve();
@@ -326,6 +329,20 @@ export default class SubscriptionPricing extends Pricing {
     if (coupon.applies_to_all_plans) return true;
     if (~coupon.plans.indexOf(this.items.plan.code)) return true;
     return false;
+  }
+
+  /**
+   * Removes the current coupon
+   *
+   * emits `unset.coupon`
+   *
+   * @private
+   */
+  removeCurrentCoupon () {
+    if (!this.items.coupon) return;
+    const currentCoupon = clone(this.items.coupon);
+    debug('unset.coupon');
+    this.remove({ coupon: currentCoupon.code }).then(() => this.emit('unset.coupon', currentCoupon));
   }
 
   /**

--- a/test/pricing/subscription/subscription.test.js
+++ b/test/pricing/subscription/subscription.test.js
@@ -518,5 +518,33 @@ describe('Recurly.Pricing.Subscription', function () {
         })
         .done();
     });
+
+    describe('when the plan is changed', () => {
+      it('removes coupons which are incompatible with the new plan', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .coupon('coop-pct-plan-basic')
+          .then(coupon => {
+            assert.equal(coupon.code, 'coop-pct-plan-basic');
+            assert.equal(this.pricing.items.coupon.code, 'coop-pct-plan-basic');
+          })
+          .reprice()
+          .then(price => {
+            assert.equal(price.now.discount, '3.00');
+            assert.equal(price.next.discount, '3.00');
+            assert.equal(price.now.total, '18.99');
+            assert.equal(price.next.total, '16.99');
+          })
+          .plan('basic-2', { quantity: 1 })
+          .done(price => {
+            assert.equal(this.pricing.items.coupon, undefined);
+            assert.equal(price.now.discount, '0.00');
+            assert.equal(price.next.discount, '0.00');
+            assert.equal(price.now.total, '95.09');
+            assert.equal(price.next.total, '90.09');
+            done();
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
- When switching plans on a `SubscriptionCheckout` instance,
  the constituent discounts must be checked for compatibility and
  removed accordingly
- Fixes #488