### PR TITLE
Make fsevents optional to allow for builds on linux systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5106,7 +5106,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.9.2",
         "node-pre-gyp": "^0.10.0"
@@ -5115,22 +5115,21 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -5138,13 +5137,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5153,32 +5150,29 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5186,22 +5180,22 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -5209,12 +5203,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -5229,7 +5223,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -5242,12 +5236,12 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
           }
@@ -5255,7 +5249,7 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -5263,7 +5257,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -5271,18 +5265,16 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5290,25 +5282,22 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5317,7 +5306,7 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -5325,7 +5314,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5333,12 +5321,12 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.1.2",
             "iconv-lite": "^0.4.4",
@@ -5348,7 +5336,7 @@
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -5365,7 +5353,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -5374,12 +5362,12 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -5388,7 +5376,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -5398,18 +5386,16 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5417,17 +5403,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -5436,17 +5422,17 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
             "ini": "~1.3.0",
@@ -5457,14 +5443,14 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -5478,45 +5464,43 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5526,7 +5510,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -5534,7 +5518,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5542,12 +5525,12 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.0.1",
             "fs-minipass": "^1.2.5",
@@ -5561,25 +5544,23 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },
@@ -8128,7 +8109,7 @@
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "combinations": "^0.1.1",
     "coveralls": "^3.0.2",
     "css-loader": "^1.0.0",
-    "fsevents": "^1.2.4",
     "glob": "^7.1.3",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^3.0.0",
@@ -86,5 +85,8 @@
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.9"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.2.4"
   }
 }


### PR DESCRIPTION
fsevents has a MacOS dependency.  Making this package optional will allow for builds on linux and other non-mac systems.