### PR TITLE
Fixes CI shimming and Object.assign introduction

### DIFF
--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -1,4 +1,4 @@
-var BROWSER = process.env.BROWSER || 'all';
+var BROWSER = process.env.BROWSER;
 var REPORT_COVERAGE = process.env.REPORT_COVERAGE || false;
 var staticConfig = require('./karma.conf').staticConfig;
 var sauceBrowsers = {
@@ -63,13 +63,14 @@ var sauceBrowsers = {
   }
 };
 
-module.exports = function (config) {
+function runner (config) {
   var reporters = ['mocha', 'saucelabs'];
   if (REPORT_COVERAGE) reporters.push('coverage');
   config.set(Object.assign({}, staticConfig, {
     reporters: reporters,
     logLevel: config.LOG_INFO,
-    browsers: browsers(),
+    browsers: ['sl_' + BROWSER],
+    frameworks: frameworks(),
     sauceLabs: {
       testName: 'Recurly.js tests',
       recordVideo: true,
@@ -79,12 +80,12 @@ module.exports = function (config) {
   }));
 };
 
-function browsers () {
-  if (BROWSER) {
-    return ['sl_' + BROWSER];
-  } else {
-    return Object.keys(sauceBrowsers);
-  }
+function frameworks () {
+  var frameworks = staticConfig.frameworks;
+  if (BROWSER === 'phantom') frameworks.push('phantomjs-shim');
+  return frameworks;
 }
 
 var server = require('./test/server');
+
+module.exports = runner;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 var staticConfig = {
   basePath: '',
-  frameworks: ['mocha', 'sinon', 'phantomjs-shim', 'source-map-support'],
+  frameworks: ['mocha', 'sinon', 'source-map-support'],
   files: [
     'build/recurly.js',
     'build/test.js'
@@ -10,6 +10,8 @@ var staticConfig = {
   port: 9876,
   colors: true,
   autoWatch: true,
+  // Warning: If PhantomJS is included, its shim framework will load in all invoked browsers.
+  //          In nearly all cases, these should be run one at a time.
   browsers: [
     'PhantomJS'
     // 'ChromeDebug'
@@ -52,9 +54,12 @@ var staticConfig = {
   }
 };
 
-var runner = function (config) {
+function runner (config) {
+  var frameworks = staticConfig.frameworks;
+  if (~staticConfig.browsers.indexOf('PhantomJS')) frameworks.push('phantomjs-shim');
   config.set(Object.assign({}, staticConfig, {
-    logLevel: config.LOG_INFO
+    logLevel: config.LOG_INFO,
+    frameworks: frameworks
   }));
 };
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ var staticConfig = {
     'PhantomJS'
     // 'ChromeDebug'
     // 'FirefoxDebug'
-    // 'IE11 - Win7'
+    // 'VirtualBoxIE11Win7'
   ],
   singleRun: true,
   concurrency: Infinity,
@@ -30,6 +30,11 @@ var staticConfig = {
     FirefoxDebug: {
       base: 'Firefox',
       flags: ['-devtools']
+    },
+    VirtualBoxIE11Win7: {
+      base: 'VirtualBoxIE11',
+      keepAlive: true,
+      vmName: 'IE11 - Win7'
     }
   },
   client: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,6 +675,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz",
+      "integrity": "sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7093,6 +7093,15 @@
         }
       }
     },
+    "karma-virtualbox-ie11-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karma-virtualbox-ie11-launcher/-/karma-virtualbox-ie11-launcher-1.2.0.tgz",
+      "integrity": "sha512-qt+sx3vxECT0kHiWnu6DensCriRZJakNm5IrEkNH5K31pJCJ0DJsId1qiknQOyr/tz4mFpBTsRSIyKzsOcVRzw==",
+      "dev": true,
+      "requires": {
+        "spawn-args": "^0.2.0"
+      }
+    },
     "keygrip": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
@@ -12375,6 +12384,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spawn-args": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
+      "integrity": "sha1-+30L0dcP1DFr2ePew4nmX51jYbs=",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-sauce-launcher": "^1.2.0",
     "karma-sinon": "^1.0.5",
     "karma-source-map-support": "^1.3.0",
+    "karma-virtualbox-ie11-launcher": "^1.2.0",
     "koa": "^2.5.3",
     "koa-bodyparser": "^4.2.1",
     "koa-cors": "0.0.16",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "@koa/cors": "^2.2.2",
     "ajv": "^6.5.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               cacheDirectory: true,
+              plugins: ['@babel/plugin-transform-object-assign'],
               presets: [
                 ['@babel/preset-env', {
                   targets: {


### PR DESCRIPTION
- Fixes #496 
- After #483, the CI environment began integrating an `Object.assign` polyfill across all test environments, masking an issue introduced in the same change where `Object.assign` calls were not transformed. This broke IE11 in the build, but prevented unit tests from identifying the issue.
- This change restricts the application of `karma-phantomjs-shim` to only runs which utilize Phantom.
- In the near future, #491 will obviate the need for the PhantomJS shim, removing this risk entirely