### PR TITLE
Isolates buses across instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+// Ensure recurly.css is included in the build
+import recurlyCSS from './lib/recurly.css';
+
+// Primary export is a single instance of Recurly
 import {Recurly} from './lib/recurly';
+
 let recurly = new Recurly;
+
 export default recurly;

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -265,7 +265,7 @@ export class Recurly extends Emitter {
     }
 
     if (this.readyState > 0) {
-      this.bus.send('hostedFields:configure!', { recurlyConfig: this.config });
+      this.bus.send('hostedFields:configure', { recurlyConfig: this.config });
       return;
     }
 

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -109,8 +109,7 @@ export class Recurly extends Emitter {
     this.reporter = new Reporter({ recurly: this });
     this.request = new Request({ recurly: this });
 
-    // @deprecated -- Old method of instantiating single-subscription Pricing
-    this.Pricing = () => new SubscriptionPricing(this);
+    this.Pricing = () => new SubscriptionPricing(this); // deprecated
     this.Pricing.Checkout = () => new CheckoutPricing(this);
     this.Pricing.Subscription = () => new SubscriptionPricing(this);
 
@@ -165,7 +164,6 @@ export class Recurly extends Emitter {
    *
    * @param  {Function} done callback
    */
-
   ready (done) {
     if (this.readyState > 1) done();
     else this.once('ready', done);
@@ -184,7 +182,6 @@ export class Recurly extends Emitter {
    *                                   tokenization. ex: ['cvv']
    * @public
    */
-
   configure (options) {
     debug('configure');
     options = clone(options);
@@ -242,20 +239,36 @@ export class Recurly extends Emitter {
   /**
    * Disables a recurly.js instance
    *
+   * - Removes all listeners
    * - Propagates a destroy call to the bus
    * - Stops the bus
+   * - Removes external references
    *
-   * TODO: mark as destroyed, prevent subsequent destruction
+   * TODO:
+   *  - destroy pricing instances, or let them live on? Currently they
+   *    may live on since their associated recurly instances remain configured
+   *    for API requests.
    */
-
   destroy () {
-    if (!this.bus) return;
-    this.bus.send('destroy');
-    this.bus.stop();
+    debug('destroying Recurly instance', this.id);
+    this.off();
+    if (this.bus) {
+      this.bus.send('destroy');
+      this.bus.destroy();
+    }
+    if (this.fraud) {
+      this.fraud.destroy();
+    }
+    if (this.reporter) {
+      this.reporter.destroy();
+      delete this.reporter;
+    }
   }
 
   /**
    * Initialize the parent recurly instance concerns: hosted fields and message bus
+   *
+   * TODO: readyState is not a good pattern
    *
    * sets this.readyState
    *   0: unconfigured
@@ -265,7 +278,6 @@ export class Recurly extends Emitter {
    *
    * @private
    */
-
   parent () {
     let reset = false;
 
@@ -286,7 +298,7 @@ export class Recurly extends Emitter {
 
     if (!this.fraud) this.fraud = new Fraud(this);
 
-    if (this.bus) this.bus.stop();
+    if (this.bus) this.bus.destroy();
     this.bus = new Bus({ api: this.config.api });
     this.bus.add(this);
 

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -240,6 +240,21 @@ export class Recurly extends Emitter {
   }
 
   /**
+   * Disables a recurly.js instance
+   *
+   * - Propagates a destroy call to the bus
+   * - Stops the bus
+   *
+   * TODO: mark as destroyed, prevent subsequent destruction
+   */
+
+  destroy () {
+    if (!this.bus) return;
+    this.bus.send('destroy');
+    this.bus.stop();
+  }
+
+  /**
    * Initialize the parent recurly instance concerns: hosted fields and message bus
    *
    * sets this.readyState

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -265,7 +265,7 @@ export class Recurly extends Emitter {
     }
 
     if (this.readyState > 0) {
-      this.bus.send('hostedFields:configure', { recurly: this.config });
+      this.bus.send('hostedFields:configure!', { recurlyConfig: this.config });
       return;
     }
 
@@ -276,8 +276,7 @@ export class Recurly extends Emitter {
     this.bus.add(this);
 
     if (!this.hostedFields || reset) {
-      const { deviceId, sessionId } = this;
-      this.hostedFields = new HostedFields({ recurly: this.config, deviceId, sessionId });
+      this.hostedFields = new HostedFields({ recurly: this });
     }
 
     if (this.hostedFields.errors.length === 0) {

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -28,9 +28,6 @@ import CheckoutPricing from './recurly/pricing/checkout';
 import SubscriptionPricing from './recurly/pricing/subscription';
 import deepAssign from './util/deep-assign';
 
-// Ensure recurly.css is included in the build
-import recurlyCSS from './recurly.css';
-
 const debug = require('debug')('recurly');
 
 /**

--- a/lib/recurly/adyen.js
+++ b/lib/recurly/adyen.js
@@ -26,7 +26,6 @@ class Adyen extends Emitter {
   constructor (options) {
     debug('Creating new Adyen session');
     super();
-
     this.recurly = options.recurly
   }
 
@@ -56,7 +55,6 @@ class Adyen extends Emitter {
 
     const frame = this.recurly.Frame({ height: 600, path: '/adyen/start', payload });
     frame.once('error', cause => this.error('adyen-error', { cause }));
-
     frame.once('done', token => this.emit('token', token));
   }
 

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -36,32 +36,12 @@ export class Bus extends Emitter {
    * @private
    * @param {MessageEvent} message
    */
-  receive (message) {
-    if (!this.originMatches(message.origin)) return;
-    if (!this.groupMatches(message)) return;
-    if (typeof message.data === 'string') return this.receiveFromRelay(message)
-    if (!message.data.event) return;
+  receive (messageEvent) {
+    if (!this.originMatches(messageEvent.origin)) return;
+    const message = Message.createFromMessageEvent(messageEvent);
+    if (!this.shouldHandleMessage(message)) return;
     this.debug('message received', message.data);
-    this.send(new Message(message), null, { exclude: [message.srcElement] });
-  }
-
-  /**
-   * Parses message properties from a JSON-encoded string
-   *
-   * @private
-   * @param  {String} message
-   * @return {Object} message
-   */
-  receiveFromRelay (message) {
-    let data;
-    try {
-      data = JSON.parse(message.data);
-    } catch (e) {
-      this.debug('failed to parse a string message', e, message);
-    }
-    if (!data) return;
-    this.debug('message received via relay', data);
-    this.send(data.recurly_event, data.recurly_message);
+    this.send(message, null, { exclude: [messageEvent.srcElement] });
   }
 
   /**
@@ -117,28 +97,25 @@ export class Bus extends Emitter {
   }
 
   /**
-   * Checks a message origin for compatibility
+   * Determines whether a message received should be handled by this bus
    *
-   * @param {String} url message origin url
    * @private
+   * @param {Message} message
    */
-  originMatches (url) {
-    return origin(url) === origin(this.config.api);
+  shouldHandleMessage (message) {
+    // If a message has a group id, it must match
+    if (message.groupId) return message.groupId === this.groupId;
+    return true;
   }
 
   /**
-   * Checks if a message is intended for this bus.
+   * Checks a message origin for compatibility
    *
-   * Accepts messages with a groupId matching this bus, and messages without a groupId
-   *
-   * @param {Message} message
-   * @return {Boolean} whether it matches
    * @private
+   * @param {String} url message origin url
    */
-  groupMatches (message) {
-    const { groupId } = message.data;
-    if (!groupId) return true;
-    return groupId === this.id;
+  originMatches (url) {
+    return origin(url) === origin(this.config.api);
   }
 }
 

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -40,9 +40,9 @@ export class Bus extends Emitter {
    */
   receive (messageEvent) {
     if (!this.originMatches(messageEvent.origin)) return;
+    this.debug('message event received', messageEvent.data);
     const message = Message.createFromMessageEvent(messageEvent, this.debug.bind(this));
     if (!this.shouldHandleMessage(message)) return;
-    this.debug('message received', message.data);
     this.send(message, null, { exclude: [messageEvent.srcElement] });
   }
 

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -15,6 +15,7 @@ export class Bus extends Emitter {
   constructor (options = {}) {
     super();
     this.id = uuid();
+    this.groupId = options.groupId || uuid();
     this.debug = require('debug')(`recurly:bus:${this.id.split('-')[0]}`);
     this.emitters = [];
     this.recipients = [];
@@ -37,6 +38,7 @@ export class Bus extends Emitter {
    */
   receive (message) {
     if (!this.originMatches(message.origin)) return;
+    if (!this.groupMatches(message)) return;
     if (typeof message.data === 'string') return this.receiveFromRelay(message)
     if (!message.data.event) return;
     this.debug('message received', message.data);
@@ -57,7 +59,9 @@ export class Bus extends Emitter {
     } catch (e) {
       this.debug('failed to parse a string message', e, message);
     }
-    if (data) this.send(new Message(data.recurly_event, data.recurly_message));
+    if (!data) return;
+    this.debug('message received via relay', data);
+    this.send(data.recurly_event, data.recurly_message);
   }
 
   /**
@@ -81,15 +85,19 @@ export class Bus extends Emitter {
    * @public
    * @param {String} event name of the message's event
    * @param {Object} body message contents
+   * @param {Object} [options]
+   * @param {Array} [options.exclude] a list of
    */
   send (event, body, options = { exclude: [] }) {
-    const message = new Message(event, body);
-    const {exclude} = options;
+    const { groupId } = this;
+    const message = new Message(event, body, groupId);
+    const { exclude } = options;
 
     this.debug(`sending message to ${this.recipients.length} recipients`, message);
     this.recipients.forEach(r => {
+      if (~exclude.indexOf(r)) return;
       if (r.postMessage) {
-        (typeof r.postMessage === 'function') && r.postMessage(message, '*');
+        if (typeof r.postMessage === 'function') r.postMessage(message, '*');
       } else if (typeof r.emit === 'function') {
         r.emit(message.event, message.body);
       }
@@ -111,10 +119,26 @@ export class Bus extends Emitter {
   /**
    * Checks a message origin for compatibility
    *
+   * @param {String} url message origin url
    * @private
    */
   originMatches (url) {
     return origin(url) === origin(this.config.api);
+  }
+
+  /**
+   * Checks if a message is intended for this bus.
+   *
+   * Accepts messages with a groupId matching this bus, and messages without a groupId
+   *
+   * @param {Message} message
+   * @return {Boolean} whether it matches
+   * @private
+   */
+  groupMatches (message) {
+    const { groupId } = message.data;
+    if (!groupId) return true;
+    return groupId === this.id;
   }
 }
 

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -1,5 +1,5 @@
 import Emitter from 'component-emitter';
-import {Message} from './message';
+import {Message, RelayMessageParseError} from './message';
 import uuid from 'uuid/v4';
 
 /**
@@ -16,7 +16,9 @@ export class Bus extends Emitter {
     super();
     this.id = uuid();
     this.groupId = options.groupId || uuid();
-    this.debug = require('debug')(`recurly:bus:${this.id.split('-')[0]}`);
+    this.debug = require('debug')(
+      `recurly:bus:${this.groupId.split('-')[0]}:${this.id.split('-')[0]}`
+    );
     this.emitters = [];
     this.recipients = [];
     this.receive = this.receive.bind(this);
@@ -38,7 +40,7 @@ export class Bus extends Emitter {
    */
   receive (messageEvent) {
     if (!this.originMatches(messageEvent.origin)) return;
-    const message = Message.createFromMessageEvent(messageEvent);
+    const message = Message.createFromMessageEvent(messageEvent, this.debug.bind(this));
     if (!this.shouldHandleMessage(message)) return;
     this.debug('message received', message.data);
     this.send(message, null, { exclude: [messageEvent.srcElement] });
@@ -56,7 +58,7 @@ export class Bus extends Emitter {
     if (~this.recipients.indexOf(recipient)) return;
     this.recipients.push(recipient);
     if (typeof recipient.emit === 'function') recipient.emit('bus:added', this);
-    this.debug('added recipient', recipient);
+    this.debug(`added recipient. Total: ${this.recipients.length}`, recipient);
   }
 
   /**

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -36,7 +36,7 @@ export class Bus extends Emitter {
    * Receives a postMessage, filters it, and sends it out
    *
    * @private
-   * @param {MessageEvent} message
+   * @param {MessageEvent} messageEvent
    */
   receive (messageEvent) {
     if (!this.originMatches(messageEvent.origin)) return;
@@ -87,13 +87,12 @@ export class Bus extends Emitter {
   }
 
   /**
-   * Stops the bus
-   *  - Empties recipients
-   *  - disconnects listener
+   * Empties recipients and disconnects the listener
    *
    * @public
    */
-  stop () {
+  destroy () {
+    this.debug('destroying bus', this.groupId, this.id);
     this.recipients = [];
     window.removeEventListener('message', this.receive, false);
   }

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -59,7 +59,7 @@ class Frame extends Emitter {
   listen (done) {
     this.recurly.bus.add(this);
 
-    // IE will not allow communication between windows;
+    // IE (including 11) will not allow communication between windows;
     // thus we must create a frame relay
     if ('documentMode' in document) {
       debug('Creating relay');

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -56,13 +56,13 @@ class Frame extends Emitter {
     this.url += (~this.url.indexOf('?') ? '&' : '?') + qs.stringify(payload, { encodeValuesOnly: true });
   }
 
-  listen (done) {
+  listen () {
     this.recurly.bus.add(this);
 
     // IE (including 11) will not allow communication between windows;
     // thus we must create a frame relay
     if ('documentMode' in document) {
-      debug('Creating relay');
+      debug('creating relay');
       let relay = document.createElement('iframe');
       relay.width = relay.height = 0;
       relay.src = this.recurly.url('/relay');
@@ -71,25 +71,21 @@ class Frame extends Emitter {
       relay.onload = () => this.create();
       window.document.body.appendChild(relay);
       this.relay = relay;
-      debug('Created relay', relay);
+      debug('created relay', relay);
     } else {
       this.create();
     }
   }
 
   create () {
-    debug('opening frame window', this.url, this.name, this.attributes);
-    window.open(this.url, this.name, this.attributes);
+    const { url, name, attributes } = this;
+    debug('opening frame window', url, name, attributes);
+    window.open(url, name, attributes);
   }
 
   get attributes () {
-    return `
-      resizable,scrollbars,
-      width=${this.width},
-      height=${this.height},
-      top=${this.top},
-      left=${this.left}
-    `;
+    const { width, height, top, left } = this;
+    return `resizable,scrollbars,width=${width},height=${height},top=${top},left=${left}`;
   }
 
   get top () {

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -47,13 +47,15 @@ class Frame extends Emitter {
     payload.key = this.recurly.config.publicKey;
 
     this.once(payload.event, res => {
-      if (this.relay) window.document.body.removeChild(this.relay);
+      this.removeRelay();
       if (res.error) this.emit('error', res.error);
       else this.emit('done', res)
     });
 
     this.url = this.recurly.url(path);
     this.url += (~this.url.indexOf('?') ? '&' : '?') + qs.stringify(payload, { encodeValuesOnly: true });
+
+    this.once('destroy', this.destroy.bind(this));
   }
 
   listen () {
@@ -79,8 +81,19 @@ class Frame extends Emitter {
 
   create () {
     const { url, name, attributes } = this;
-    debug('opening frame window', url, name, attributes);
-    window.open(url, name, attributes);
+    this.window = window.open(url, name, attributes);
+    debug('opening frame window', this.window, url, name, attributes);
+  }
+
+  destroy () {
+    this.off();
+    if (this.window) this.window.close();
+    this.removeRelay();
+  }
+
+  removeRelay () {
+    if (!this.relay) return;
+    window.document.body.removeChild(this.relay);
   }
 
   get attributes () {

--- a/lib/recurly/fraud.js
+++ b/lib/recurly/fraud.js
@@ -9,10 +9,9 @@ const debug = require('debug')('recurly:fraud');
 export class Fraud extends Emitter {
   constructor (recurly) {
     super();
-
     this.recurly = recurly;
     this.dataCollectorInitiated = false;
-
+    this.attachedNodes = [];
     if (this.shouldCollectData) {
       recurly.ready(this.dataCollector.bind(this));
     }
@@ -97,6 +96,19 @@ export class Fraud extends Emitter {
     var tempContainer = document.createElement('div');
     tempContainer.innerHTML = contentString;
 
-    each(tempContainer.childNodes, node => this.form.appendChild(node));
+    each(tempContainer.childNodes, node => {
+      this.attachedNodes.push(node);
+      this.form.appendChild(node)
+    });
+  }
+
+  /**
+   * Removes any attached data collectors
+   */
+  destroy () {
+    this.attachedNodes.forEach(node => {
+      if (!node.parentElement) return;
+      node.parentElement.removeChild(node);
+    });
   }
 }

--- a/lib/recurly/hosted-field.js
+++ b/lib/recurly/hosted-field.js
@@ -24,6 +24,7 @@ export class HostedField extends Emitter {
     this.onConfigure = this.onConfigure.bind(this);
     this.onStateChange = this.onStateChange.bind(this);
     this.focus = this.focus.bind(this);
+    this.destroy = this.destroy.bind(this);
 
     this.ready = false;
     this.state = {};
@@ -36,11 +37,11 @@ export class HostedField extends Emitter {
       this.bus.add(this.window);
     });
 
-    // TODO: need these to be specific to this instance
     this.on('hostedField:ready', this.onReady);
     this.on('hostedField:change', this.onChange);
     this.on('hostedField:configure', this.onConfigure);
     this.on('hostedField:state:change', this.onStateChange);
+    this.on('destroy', this.destroy);
   }
 
   get type () {
@@ -132,6 +133,8 @@ export class HostedField extends Emitter {
    * Binds focus on the following elements to the `focus!` event on the hosted field
    *  - the container element
    *  - `<label>` elements with a `for` attribute matching the target `id` attribute
+   *
+   * @private
    */
   bindDeferredFocus () {
     this.container.addEventListener('click', this.focus);
@@ -142,9 +145,15 @@ export class HostedField extends Emitter {
     });
   }
 
-  reset () {
+  /**
+   * Removes listeners, and clears references
+   *
+   * @private
+   */
+  destroy () {
+    debug(`destroying ${this.type} hosted field`);
     this.off();
-    this.target.innerHTML = '';
+    if (this.target) this.target.innerHTML = '';
     delete this.target;
     delete this.iframe;
     delete this.window;
@@ -181,6 +190,9 @@ export class HostedField extends Emitter {
     this.update();
   }
 
+  /**
+   * Places focus on this hosted field
+   */
   focus () {
     if (!this.bus) return;
     this.bus.send(`hostedField:${this.type}:focus!`);

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -15,13 +15,12 @@ export const FIELD_TYPES = ['number', 'month', 'year', 'cvv', 'card'];
  *
  * @constructor
  * @param {Object} options
- * @param {Object} options.recurly options to init a recurly instance
- * @param {String} options.version
+ * @param {Recurly} options.recurly Associated Recurly instance
  * @public
  */
 
 export class HostedFields extends Emitter {
-  constructor (options) {
+  constructor ({ recurly }) {
     super();
     this.ready = false;
     this.state = {};
@@ -29,7 +28,8 @@ export class HostedFields extends Emitter {
     this.errors = [];
     this.initQueue = [];
     this.readyState = 0;
-    this.configure(options);
+    this.recurly = recurly;
+    this.configure(recurly.config);
     this.inject();
     this.on('hostedField:tab:previous', message => this.onTab('previous', message));
     this.on('hostedField:tab:next', message => this.onTab('next', message));
@@ -53,7 +53,7 @@ export class HostedFields extends Emitter {
     if (fields) {
       const newSelectors = Object.keys(fields).map(key => fields[key].selector).join('');
       const currentSelectors = Object.keys(this.config.recurly.fields).map(key => {
-        return this.config.recurly.fields[key].selector
+        return this.config.recurly.fields[key].selector;
       }).join('');
       if (newSelectors !== currentSelectors) return false;
     }
@@ -62,8 +62,10 @@ export class HostedFields extends Emitter {
 
   // Private
 
-  configure (options) {
-    this.config = clone(options || {});
+  configure (recurlyConfig) {
+    this.config = {
+      recurly: clone(recurlyConfig || {})
+    };
   }
 
   inject () {
@@ -95,8 +97,8 @@ export class HostedFields extends Emitter {
       this.errors = this.errors.filter(e => e.name !== 'missing-hosted-field-target');
     }
 
-    this.on('hostedFields:configure', (options) => {
-      this.configure(options);
+    this.on('hostedFields:configure!', opts => {
+      this.configure(opts.recurlyConfig);
       this.fields.forEach(field => {
         if (this.bus) this.bus.send('hostedField:configure', this.fieldConfig(field.type));
       });
@@ -151,6 +153,7 @@ export class HostedFields extends Emitter {
   fieldConfig (type) {
     const fields = this.config.recurly.fields;
     const field = fields[type];
+    const busGroupId = this.recurly.bus.groupId;
     const { deviceId, sessionId } = this.config;
     const { displayIcon, inputType, selector } = field;
     if (!fields[type]) return;
@@ -158,6 +161,7 @@ export class HostedFields extends Emitter {
       type,
       deviceId,
       sessionId,
+      busGroupId,
       displayIcon,
       inputType,
       selector,

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -31,6 +31,13 @@ export class HostedFields extends Emitter {
     this.recurly = recurly;
     this.configure(recurly.config);
     this.inject();
+    this.on('hostedFields:configure', opts => {
+      this.configure(opts.recurlyConfig);
+      this.fields.forEach(field => {
+        if (this.bus) this.bus.send('hostedField:configure', this.fieldConfig(field.type));
+      });
+    });
+    this.on('hostedField:ready', this.onReady.bind(this));
     this.on('hostedField:tab:previous', message => this.onTab('previous', message));
     this.on('hostedField:tab:next', message => this.onTab('next', message));
     this.on('hostedField:state:change', this.update.bind(this));
@@ -38,6 +45,7 @@ export class HostedFields extends Emitter {
       this.bus = bus;
       this.fields.forEach(hf => bus.add(hf));
     });
+    this.once('destroy', this.destroy.bind(this));
   }
 
   /**
@@ -62,14 +70,12 @@ export class HostedFields extends Emitter {
 
   // Private
 
-  configure (recurlyConfig) {
-    this.config = {
-      recurly: clone(recurlyConfig || {})
-    };
-  }
-
+  /**
+   * Creates HostedField instances
+   *
+   * @private
+   */
   inject () {
-    this.on('hostedField:ready', this.onReady.bind(this));
     FIELD_TYPES.forEach(type => {
       try {
         this.fields.push(new HostedField(this.fieldConfig(type)));
@@ -96,23 +102,39 @@ export class HostedFields extends Emitter {
     } else {
       this.errors = this.errors.filter(e => e.name !== 'missing-hosted-field-target');
     }
-
-    this.on('hostedFields:configure', opts => {
-      this.configure(opts.recurlyConfig);
-      this.fields.forEach(field => {
-        if (this.bus) this.bus.send('hostedField:configure', this.fieldConfig(field.type));
-      });
-    });
   }
 
+  configure (recurlyConfig) {
+    this.config = {
+      recurly: clone(recurlyConfig || {})
+    };
+  }
+
+  /**
+   * Resets instance to its initial state
+   *
+   * FIXME: Remove reset routines in favor of re-instantiation
+   *
+   * @private
+   */
   reset () {
     this.off();
     this.ready = false;
     this.readyState = 0;
-    this.fields.forEach(field => field.reset());
+    this.fields.forEach(field => field.destroy());
     this.fields = [];
     this.errors = [];
     this.initQueue = [];
+  }
+
+  /**
+   * Removes listeners and external references
+   */
+  destroy () {
+    debug('destroying HostedFields');
+    this.off();
+    delete this.fields;
+    delete this.recurly;
   }
 
   onReady (body) {

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -97,7 +97,7 @@ export class HostedFields extends Emitter {
       this.errors = this.errors.filter(e => e.name !== 'missing-hosted-field-target');
     }
 
-    this.on('hostedFields:configure!', opts => {
+    this.on('hostedFields:configure', opts => {
       this.configure(opts.recurlyConfig);
       this.fields.forEach(field => {
         if (this.bus) this.bus.send('hostedField:configure', this.fieldConfig(field.type));

--- a/lib/recurly/message.js
+++ b/lib/recurly/message.js
@@ -6,20 +6,15 @@
  */
 
 export class Message {
-  constructor (event, body = {}) {
+  constructor (event, body = {}, groupId) {
     if (event instanceof Message) return event;
     if (event instanceof window.MessageEvent) {
-      body = event.data.body;
       event = event.data.event;
+      body = event.data.body;
+      groupId = event.data.groupId;
     }
     this.event = event;
     this.body = body;
-  }
-
-  format () {
-    return {
-      event: this.event,
-      body: this.body
-    }
+    this.groupId = groupId;
   }
 }

--- a/lib/recurly/message.js
+++ b/lib/recurly/message.js
@@ -20,11 +20,14 @@ export class Message {
    * @param  {MessageEvent} messageEvent
    * @return {Message}
    */
-  static createFromMessageEvent (messageEvent) {
+  static createFromMessageEvent (messageEvent, debug = debug) {
     let data = messageEvent.data;
 
     // Parse a MessageEvent which originates from a relay
-    if (typeof data === 'string') data = dataFromRelayMessageEvent(data);
+    if (typeof data === 'string') {
+      debug('attempting to parse a relay-like message', data);
+      data = dataFromRelayMessageEvent(data, debug);
+    }
 
     if (!data) return;
 
@@ -40,17 +43,20 @@ export class Message {
  * @param  {String} data message data as a JSON string
  * @return {Object} parsed message data: { event, body }
  */
-function dataFromRelayMessageEvent (data) {
+function dataFromRelayMessageEvent (data, debug) {
   try {
     data = JSON.parse(data);
-    debug('message received via relay', data);
-    if (!data) return;
-    return {
-      event: data.recurly_event,
-      body: data.recurly_message
-    };
   } catch (e) {
-    debug('failed to parse a string message', e, data);
+    debug('failed to parse relay message', e, messageEvent);
+  }
+
+  if (!data) {
+    debug('no data in relay message');
     return;
   }
+
+  return {
+    event: data.recurly_event,
+    body: data.recurly_message
+  };
 }

--- a/lib/recurly/message.js
+++ b/lib/recurly/message.js
@@ -26,7 +26,7 @@ export class Message {
     // Parse a MessageEvent which originates from a relay
     if (typeof data === 'string') {
       debug('attempting to parse a relay-like message', data);
-      data = dataFromRelayMessageEvent(data, debug);
+      data = dataFromRelayMessageEvent(messageEvent, debug);
     }
 
     if (!data) return;
@@ -43,7 +43,9 @@ export class Message {
  * @param  {String} data message data as a JSON string
  * @return {Object} parsed message data: { event, body }
  */
-function dataFromRelayMessageEvent (data, debug) {
+function dataFromRelayMessageEvent (messageEvent, debug) {
+  let data = messageEvent.data;
+
   try {
     data = JSON.parse(data);
   } catch (e) {

--- a/lib/recurly/message.js
+++ b/lib/recurly/message.js
@@ -1,20 +1,56 @@
+const debug = require('debug')('recurly:message');
+
 /**
  * Message
  *
  * @param {String|Message|MessageEvent} event message event name or Message or MessageEvent
  * @param {Object} body message contents
  */
-
 export class Message {
   constructor (event, body = {}, groupId) {
     if (event instanceof Message) return event;
-    if (event instanceof window.MessageEvent) {
-      event = event.data.event;
-      body = event.data.body;
-      groupId = event.data.groupId;
-    }
     this.event = event;
     this.body = body;
     this.groupId = groupId;
+  }
+
+  /**
+   * Creates a message from a window.MessageEvent
+   *
+   * @param  {MessageEvent} messageEvent
+   * @return {Message}
+   */
+  static createFromMessageEvent (messageEvent) {
+    let data = messageEvent.data;
+
+    // Parse a MessageEvent which originates from a relay
+    if (typeof data === 'string') data = dataFromRelayMessageEvent(data);
+
+    if (!data) return;
+
+    return new Message(data.event, data.body, data.groupId);
+  }
+}
+
+/**
+ * Parses a messageEvent coming from a Frame relay
+ *
+ * NOTE: groupId is not handled because Frames subscribe to unique topics
+ *
+ * @param  {String} data message data as a JSON string
+ * @return {Object} parsed message data: { event, body }
+ */
+function dataFromRelayMessageEvent (data) {
+  try {
+    data = JSON.parse(data);
+    debug('message received via relay', data);
+    if (!data) return;
+    return {
+      event: data.recurly_event,
+      body: data.recurly_message
+    };
+  } catch (e) {
+    debug('failed to parse a string message', e, data);
+    return;
   }
 }

--- a/lib/recurly/reporter.js
+++ b/lib/recurly/reporter.js
@@ -33,6 +33,19 @@ export class Reporter {
   }
 
   /**
+   * Stops the worker and removes external references
+   *
+   * @return {[type]} [description]
+   */
+  destroy () {
+    debug('destroying reporter');
+    if (this.worker) {
+      this.worker.destroy();
+      delete this.worker;
+    }
+  }
+
+  /**
    * Whether events should be dispatched
    *
    * @return {Boolean}

--- a/test/hosted-fields.test.js
+++ b/test/hosted-fields.test.js
@@ -6,18 +6,20 @@ import {FIELD_TYPES, HostedFields} from '../lib/recurly/hosted-fields';
 import {Recurly} from '../lib/recurly';
 
 describe('Recurly.HostedFields', function () {
-  beforeEach(function (done) {
-    this.recurly = initRecurly();
-    this.recurly.ready(done);
-    this.hostedFields = new HostedFields({ recurly: this.recurly.config });
-    this.hostedField = this.hostedFields.fields[0];
-  });
-
   applyFixtures();
 
-  describe('initialization', function () {
-    this.ctx.fixture = 'all';
+  this.ctx.fixture = 'all';
 
+  beforeEach(function (done) {
+    const recurly = this.recurly = initRecurly();
+    this.recurly.ready(() => {
+      this.hostedFields = new HostedFields({ recurly });
+      this.hostedField = this.hostedFields.fields[0];
+      done();
+    });
+  });
+
+  describe('initialization', function () {
     it('builds fields collection', function () {
       for (let i = 0; i < this.hostedFields.fields.length; i++) {
         assert(this.hostedFields.fields[i]);
@@ -33,9 +35,6 @@ describe('Recurly.HostedFields', function () {
     stubAsMobileDevice();
 
     beforeEach(function (done) {
-      this.recurly = initRecurly();
-      this.hostedFields = new HostedFields({ recurly: this.recurly.config });
-      this.hostedField = this.hostedFields.fields[0];
       sinon.spy(this.hostedFields, 'onTab');
       sinon.spy(this.hostedFields, 'tabbableItems');
       this.recurly.ready(done);
@@ -45,8 +44,6 @@ describe('Recurly.HostedFields', function () {
       this.hostedFields.onTab.restore();
       this.hostedFields.tabbableItems.restore();
     });
-
-    this.ctx.fixture = 'all';
 
     it('binds to specific events', function () {
       [
@@ -75,8 +72,6 @@ describe('Recurly.HostedFields', function () {
   });
 
   describe('fieldConfig', () => {
-    this.ctx.fixture = 'all';
-
     describe('format', () => {
       it('prefers the individual field config value', function () {
         this.recurly.configure({
@@ -86,7 +81,7 @@ describe('Recurly.HostedFields', function () {
           }
         });
 
-        let fieldConfig = new HostedFields({ recurly: this.recurly.config }).fieldConfig('number');
+        let fieldConfig = new HostedFields({ recurly: this.recurly }).fieldConfig('number');
         assert.strictEqual(fieldConfig.format, false);
       });
 
@@ -97,7 +92,7 @@ describe('Recurly.HostedFields', function () {
           }
         });
 
-        let fieldConfig = new HostedFields({ recurly: this.recurly.config }).fieldConfig('number');
+        let fieldConfig = new HostedFields({ recurly: this.recurly }).fieldConfig('number');
         assert.strictEqual(fieldConfig.format, true);
       });
     });
@@ -111,7 +106,7 @@ describe('Recurly.HostedFields', function () {
           }
         });
 
-        let fieldConfig = new HostedFields({ recurly: this.recurly.config }).fieldConfig('number');
+        let fieldConfig = new HostedFields({ recurly: this.recurly }).fieldConfig('number');
         assert.strictEqual(fieldConfig.tabIndex, 0);
       });
 
@@ -122,7 +117,7 @@ describe('Recurly.HostedFields', function () {
           }
         });
 
-        let fieldConfig = new HostedFields({ recurly: this.recurly.config }).fieldConfig('number');
+        let fieldConfig = new HostedFields({ recurly: this.recurly }).fieldConfig('number');
         assert.strictEqual(fieldConfig.tabIndex, 200);
       });
     });

--- a/test/server/fixtures/field.html.ejs
+++ b/test/server/fixtures/field.html.ejs
@@ -9,6 +9,7 @@
     window.inputValue = '';
     window._config = undefined;
 
+    // Stub broker behavior
     if (config().type === 'number') {
       window.addEventListener('message', receive, false);
     }
@@ -36,7 +37,9 @@
     }
 
     function message (name, body) {
-      if (window.parent) window.parent.postMessage({ event: name, body: body }, '*');
+      if (!window.parent) return;
+      const groupId = config().busGroupId;
+      window.parent.postMessage({ event: name, body: body, groupId: groupId }, '*');
     }
 
     function recurlyConfig() {


### PR DESCRIPTION
- Allows multiple `recurly` instances to co-exist in a single `window`
- Adds a `bus.groupId` uuid which identifies `Messages` intended to be isolated to a particular `Bus` group
- A `recurly` instance will pass its `groupId` along to its dependent hosted fields, allowing those hosted fields to isolate their messages to that `recurly` instance.
- Improves `Message` parsing across relays