### PR TITLE
Fixes Edge 44 bug when adding an iframe as a bus recipient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ env:
     - secure: Bv5h9pXMa5O0EdOuN2Dt1n9/+T1dMHimnn6XQb0ozjfwzjfhcPR6eKHkOxDVJ0c1rzne48ql0FK0P42QaCdZpEmy8wUyUTmI1gTMhjILcFbQFk+r9GOwGJsPttLNRS2J9+8u5tEDZjf5LiCnPBjy6vIinK7nlas93xTLTQwNEmI=
     - secure: yIrHdkLhWtO37N24cRU71PK80zvkPzlJ1Jm+1MS3C6/icgJ8At1N/UgpBdxuBs1tlJm1O7Ahk+/MhpGWlspx9tCF7Hzw9Rj0xpKhqsvM155zgH582xNPwNebiCr/tmsH2/ELgFBBgC9sCW5luzeKx9nyuedGA4fmD2fK5Phc5EE=
   matrix:
-    - BROWSER=chrome_headless ARTIFACTS_BUCKET=recurly-js REPORT_COVERAGE=true
-    - BROWSER=chrome
-    - BROWSER=firefox
-    - BROWSER=safari
+    # - BROWSER=chrome_headless ARTIFACTS_BUCKET=recurly-js REPORT_COVERAGE=true
+    # - BROWSER=chrome
+    # - BROWSER=firefox
+    # - BROWSER=safari
     - BROWSER=edge
-    - BROWSER=ie_11
-    - BROWSER=ios_12
-    - BROWSER=ios_11
-    - BROWSER=android_7
-    - BROWSER=android_6
-    - BROWSER=android_5
+    # - BROWSER=ie_11
+    # - BROWSER=ios_12
+    # - BROWSER=ios_11
+    # - BROWSER=android_7
+    # - BROWSER=android_6
+    # - BROWSER=android_5

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ env:
     - secure: Bv5h9pXMa5O0EdOuN2Dt1n9/+T1dMHimnn6XQb0ozjfwzjfhcPR6eKHkOxDVJ0c1rzne48ql0FK0P42QaCdZpEmy8wUyUTmI1gTMhjILcFbQFk+r9GOwGJsPttLNRS2J9+8u5tEDZjf5LiCnPBjy6vIinK7nlas93xTLTQwNEmI=
     - secure: yIrHdkLhWtO37N24cRU71PK80zvkPzlJ1Jm+1MS3C6/icgJ8At1N/UgpBdxuBs1tlJm1O7Ahk+/MhpGWlspx9tCF7Hzw9Rj0xpKhqsvM155zgH582xNPwNebiCr/tmsH2/ELgFBBgC9sCW5luzeKx9nyuedGA4fmD2fK5Phc5EE=
   matrix:
-    # - BROWSER=chrome_headless ARTIFACTS_BUCKET=recurly-js REPORT_COVERAGE=true
-    # - BROWSER=chrome
-    # - BROWSER=firefox
-    # - BROWSER=safari
+    - BROWSER=chrome_headless ARTIFACTS_BUCKET=recurly-js REPORT_COVERAGE=true
+    - BROWSER=chrome
+    - BROWSER=firefox
+    - BROWSER=safari
     - BROWSER=edge
-    # - BROWSER=ie_11
-    # - BROWSER=ios_12
-    # - BROWSER=ios_11
-    # - BROWSER=android_7
-    # - BROWSER=android_6
-    # - BROWSER=android_5
+    - BROWSER=ie_11
+    - BROWSER=ios_12
+    - BROWSER=ios_11
+    - BROWSER=android_7
+    - BROWSER=android_6
+    - BROWSER=android_5

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,8 +10,6 @@ var staticConfig = {
   port: 9876,
   colors: true,
   autoWatch: true,
-  // Warning: If PhantomJS is included, its shim framework will load in all invoked browsers.
-  //          In nearly all cases, these should be run one at a time.
   browsers: [
     'ChromeHeadless'
     // 'ChromeDebug'

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -57,9 +57,7 @@ export class Bus extends Emitter {
   add (recipient) {
     if (~this.recipients.indexOf(recipient)) return;
     this.recipients.push(recipient);
-    // Leaving this in will demonstrate the error case in Edge 44
-    if (typeof recipient.emit === 'function') recipient.emit('bus:added', this);
-    // if (recipient instanceof Emitter) recipient.emit('bus:added', this);
+    if (recipient instanceof Emitter) recipient.emit('bus:added', this);
     this.debug(`added recipient. Total: ${this.recipients.length}`, recipient);
   }
 

--- a/lib/recurly/bus.js
+++ b/lib/recurly/bus.js
@@ -57,7 +57,9 @@ export class Bus extends Emitter {
   add (recipient) {
     if (~this.recipients.indexOf(recipient)) return;
     this.recipients.push(recipient);
+    // Leaving this in will demonstrate the error case in Edge 44
     if (typeof recipient.emit === 'function') recipient.emit('bus:added', this);
+    // if (recipient instanceof Emitter) recipient.emit('bus:added', this);
     this.debug(`added recipient. Total: ${this.recipients.length}`, recipient);
   }
 

--- a/test/adyen.test.js
+++ b/test/adyen.test.js
@@ -4,7 +4,7 @@ import after from 'lodash.after';
 import merge from 'lodash.merge';
 import {Recurly} from '../lib/recurly';
 import {fixture} from './support/fixtures';
-import {initRecurly, apiTest, domTest} from './support/helpers';
+import {initRecurly, apiTest} from './support/helpers';
 
 
 apiTest(function (requestMethod) {

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -38,7 +38,7 @@ describe('Recurly.Bus', function () {
       })
     });
 
-    describe.only('when adding a cross-domain iframe window recipient', function () {
+    describe('when adding a cross-domain iframe window recipient', function () {
       applyFixtures();
 
       this.ctx.fixture = 'iframe';

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -1,0 +1,59 @@
+import assert from 'assert';
+import {applyFixtures} from './support/fixtures';
+import {Bus} from '../lib/recurly/bus';
+import Emitter from 'component-emitter';
+
+describe('Recurly.Bus', function () {
+  beforeEach(function () {
+    this.bus = new Bus({ api: `//${window.location.host}/api` });
+  });
+
+  afterEach(function () {
+    this.bus.destroy();
+  });
+
+  describe('Bus.add', () => {
+    describe('when adding an Emitter recipient', function () {
+      beforeEach(function () {
+        this.exampleEmitters = [
+          (new Emitter),
+          (new EmitterInheritant)
+        ];
+      });
+
+      it('adds the Emitters to the recipients', function () {
+        this.exampleEmitters.forEach(exampleEmitter => {
+          this.bus.add(exampleEmitter);
+          assert.strictEqual(!!~this.bus.recipients.indexOf(exampleEmitter), true);
+        });
+      });
+
+      it('emits `bus:added` to the Emitter', function (done) {
+        const exampleEmitter = new Emitter;
+        exampleEmitter.on('bus:added', bus => {
+          assert.strictEqual(bus, this.bus);
+          done();
+        })
+        this.bus.add(exampleEmitter);
+      })
+    });
+
+    describe.only('when adding a cross-domain iframe window recipient', function () {
+      applyFixtures();
+
+      this.ctx.fixture = 'iframe';
+
+      beforeEach(function () {
+        const iframe = document.querySelector('#test-iframe');
+        this.exampleIFrameWindow = iframe.contentWindow;
+      });
+
+      it('will add the window to bus.recipients', function () {
+        this.bus.add(this.exampleIFrameWindow);
+        assert.strictEqual(!!~this.bus.recipients.indexOf(this.exampleIFrameWindow), true);
+      });
+    });
+  });
+});
+
+class EmitterInheritant extends Emitter {}

--- a/test/support/fixtures.js
+++ b/test/support/fixtures.js
@@ -157,7 +157,22 @@ const multipleForms = opts => `
   </form>
 `;
 
-const FIXTURES = { minimal, all, bank, pricing, checkoutPricing, multipleForms };
+const iframe = opts => `
+  <iframe
+    id="${fetch(opts, 'id', 'test-iframe')}"
+    src="${fetch(opts, 'src', 'https://google.com')}"
+  ></iframe>
+`;
+
+const FIXTURES = {
+  minimal,
+  all,
+  bank,
+  pricing,
+  checkoutPricing,
+  multipleForms,
+  iframe
+};
 
 export function applyFixtures () {
   beforeEach(function () {


### PR DESCRIPTION
- Type checking a cross-domain window property throws an error in Edge 44 (EdgeHTML 18)
- This replaces property detection with prototype chain inspection
- Fixes #509