### PR TITLE
Emit PayPal cancel event on frame close

### DIFF
--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -200,9 +200,8 @@ class Frame extends Emitter {
   createWindow () {
     const { name, url, windowAttributes } = this;
     this.window = window.open(url, name, windowAttributes);
-    debug(`opening window`, this.window, url, name, windowAttributes);]
+    debug(`opening window`, this.window, url, name, windowAttributes);
     this.bindWindowCloseListener();
-    debug('opening frame window', this.window, url, name, attributes);
   }
 
   /**

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -200,7 +200,9 @@ class Frame extends Emitter {
   createWindow () {
     const { name, url, windowAttributes } = this;
     this.window = window.open(url, name, windowAttributes);
-    debug(`opening window`, this.window, url, name, windowAttributes);
+    debug(`opening window`, this.window, url, name, windowAttributes);]
+    this.bindWindowCloseListener();
+    debug('opening frame window', this.window, url, name, attributes);
   }
 
   /**
@@ -257,6 +259,20 @@ class Frame extends Emitter {
     if (!this.relay) return;
     if (!window.document.body.contains(this.relay)) return;
     window.document.body.removeChild(this.relay);
+  }
+
+  bindWindowCloseListener () {
+    const tick = setInterval(() => {
+      if (!this.window) {
+        return clearInterval(tick);
+      }
+      if (this.window.closed) {
+        debug('detected frame window closure. Destroying.', this.window);
+        clearInterval(tick);
+        this.emit('close');
+        this.destroy();
+      }
+    }, 1000);
   }
 }
 

--- a/lib/recurly/paypal/strategy/direct.js
+++ b/lib/recurly/paypal/strategy/direct.js
@@ -23,8 +23,12 @@ export class DirectStrategy extends PayPalStrategy {
   start () {
     const { payload } = this;
     const frame = this.recurly.Frame({ path: '/paypal/start', payload });
-    frame.once('error', cause => this.error('paypal-tokenize-error', { cause }));
     frame.once('done', token => this.emit('token', token));
+    frame.once('close', () => this.emit('cancel'));
+    frame.once('error', cause => {
+      if (cause.code === 'paypal-cancel') this.emit('cancel');
+      this.error('paypal-tokenize-error', { cause })
+    });
   }
 }
 

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -28,12 +28,6 @@ describe('Recurly.Frame', function () {
       this.frame = this.recurly.Frame({ path });
       done();
     });
-
-    // Returns a spy so frame.bindWindowCloseListener does not cancel the tick
-    const windowStub = { close: () => { windowStub.closed = true; }, closed: false };
-    window.open = sinon.spy(() => windowStub);
-
-    sinon.stub(window.document.body, 'appendChild').callsFake(relay => relay.onload());
   });
 
   afterEach(function () {
@@ -192,6 +186,7 @@ describe('Recurly.Frame', function () {
   });
 
   it('emits a closed event when the frame closes', function (done) {
+    this.newWindow = { close: () => this.newWindow.closed = true, closed: false };
     this.timeout(2000); // timeout with error if frame doesn't emit close event
     const frame = this.recurly.Frame({ path }).on('close', () => done());
     frame.window.close();

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -28,6 +28,11 @@ describe('Recurly.Frame', function () {
       this.frame = this.recurly.Frame({ path });
       done();
     });
+
+    // Returns a spy so frame.bindWindowCloseListener does not cancel the tick
+    window.open = sinon.spy(() => sinon.spy());
+
+    sinon.stub(window.document.body, 'appendChild').callsFake(relay => relay.onload());
   });
 
   afterEach(function () {
@@ -183,5 +188,13 @@ describe('Recurly.Frame', function () {
         });
       });
     });
+  });
+
+  it('emits a closed event when the frame closes', function (done) {
+    this.timeout(2000); // timeout with error if frame doesn't emit close event
+
+    this.recurly.Frame({ path }).on('close', () => done());
+
+    frame.window = {closed: true}; // stub the window closing
   });
 });

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -30,7 +30,8 @@ describe('Recurly.Frame', function () {
     });
 
     // Returns a spy so frame.bindWindowCloseListener does not cancel the tick
-    window.open = sinon.spy(() => sinon.spy());
+    const windowStub = { close: () => { windowStub.closed = true; }, closed: false };
+    window.open = sinon.spy(() => windowStub);
 
     sinon.stub(window.document.body, 'appendChild').callsFake(relay => relay.onload());
   });
@@ -192,9 +193,7 @@ describe('Recurly.Frame', function () {
 
   it('emits a closed event when the frame closes', function (done) {
     this.timeout(2000); // timeout with error if frame doesn't emit close event
-
-    this.recurly.Frame({ path }).on('close', () => done());
-
-    frame.window = {closed: true}; // stub the window closing
+    const frame = this.recurly.Frame({ path }).on('close', () => done());
+    frame.window.close();
   });
 });

--- a/test/paypal/strategy/direct.test.js
+++ b/test/paypal/strategy/direct.test.js
@@ -48,4 +48,12 @@ describe('DirectStrategy', function () {
       })));
     });
   });
+
+  it('emits a cancel event when the window closes', function(done) {
+    this.timeout(2000); // timeout with error if paypal doesn't emit cancel event
+    this.paypal.on('cancel', () => done());
+    this.paypal.start();
+    this.recurly.Frame.getCall(0).returnValue
+      .window.close();
+  });
 });

--- a/test/paypal/strategy/direct.test.js
+++ b/test/paypal/strategy/direct.test.js
@@ -49,11 +49,10 @@ describe('DirectStrategy', function () {
     });
   });
 
-  it('emits a cancel event when the window closes', function(done) {
-    this.timeout(2000); // timeout with error if paypal doesn't emit cancel event
+  it('emits a cancel event when the window closes', function (done) {
+    this.timeout(2500); // timeout with error if paypal doesn't emit cancel event
     this.paypal.on('cancel', () => done());
     this.paypal.start();
-    this.recurly.Frame.getCall(0).returnValue
-      .window.close();
+    setTimeout(() => this.recurly.Frame.getCall(0).returnValue.emit('close'), 500);
   });
 });


### PR DESCRIPTION
Fixes #520 

This allows library users to listen for a `cancel` event that is emitted when the popup window for PayPal closes.

Example usage:
```javascript
this.paypal.on('cancel', () => {
    // react to the window closing
});
```