### PR TITLE
Update adyen.js

### DIFF
--- a/lib/recurly/adyen.js
+++ b/lib/recurly/adyen.js
@@ -36,6 +36,7 @@ class Adyen extends Emitter {
    * @param {String} opts.countryCode - 2 Digit Country Code
    * @param {String} opts.shopperLocale - shopperLocale for Payment Modal
    * @param {String} opts.skinCode - Skin code provided by Adyen
+   * @param {String} opts.brandCode - Brand code for the Adyen HPP (eg. mc, visa, ideal, paypal)
   */
   start (opts) {
     debug('Invoking Adyen Modal');
@@ -44,7 +45,8 @@ class Adyen extends Emitter {
       invoiceUuid: opts.invoiceUuid,
       countryCode: opts.countryCode,
       shopperLocale: opts.shopperLocale,
-      skinCode: opts.skinCode
+      skinCode: opts.skinCode,
+      brandCode: opts.brandCode,
     };
 
     var errors = validatePayload(payload)


### PR DESCRIPTION
I've added the brandCode parameter, which allows to skip the payment method selection and save the user a click.
This is great if you need to support only one payment method using Adyen, in our case iDEAL.