### PR TITLE
Fixes loading Braintree libraries

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/braintree.js
+++ b/lib/recurly/risk/three-d-secure/strategy/braintree.js
@@ -83,7 +83,7 @@ export default class BraintreeStrategy extends ThreeDSecureStrategy {
    */
   loadBraintreeLibraries () {
     return new Promise((resolve, reject) => {
-      if (window.braintree.client && window.braintree.threeDSecure) return resolve();
+      if (window.braintree && window.braintree.client && window.braintree.threeDSecure) return resolve();
       loadScript(this.urlForResource('client'), error => {
         if (error) reject(error);
         else loadScript(this.urlForResource('three-d-secure'), error => {


### PR DESCRIPTION
When loading the Braintree libraries the code checks if `window.braintree.client` and `window.braintree.threeDSecure` exist, but not `window.braintree`. The first time the `loadBraintreeLibraries` method is called it throws an error: `TypeError: "window.braintree is undefined"`. This PR adds the additional check for `window.braintree` to avoid the error 🙂 