### PR TITLE
updates Frame to use enum instead of string types

### DIFF
--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -11,7 +11,7 @@ const debug = require('debug')('recurly:frame');
  * @property {Recurly} recurly
  * @property {String} path            API endpoint to load
  * @property {Object} payload         Message payload to deliver to endpoint
- * @property {TYPE} [type=0]          window or iframe
+ * @property {TYPE} [type=Frame.TYPES.WINDOW]          window or iframe
  * @property {HTMLElement} container  only valid for type='iframe' --
  *                                      attaches iframe to this container
  * @property {Number} [height=450]    frame height
@@ -32,23 +32,20 @@ export function factory (options) {
 }
 
 /**
- * @enum {Number}
- */
-export const TYPE = {
-  WINDOW: 0,
-  IFRAME: 1
-};
-
-/**
  * Issues an API request to a popup window.
  *
  * @param {FrameOptions} options
  */
-class Frame extends Emitter {
+export class Frame extends Emitter {
+  static TYPES = {
+    WINDOW: 0,
+    IFRAME: 1
+  };
+
   static DEFAULTS = {
     height: 535,
     width: 450,
-    type: TYPE.WINDOW
+    type: Frame.TYPES.WINDOW
   };
 
   constructor ({ recurly, path, payload = {}, ...options }) {
@@ -66,7 +63,7 @@ class Frame extends Emitter {
    * @type {Boolean}
    */
   get isIframe () {
-    return this.type === TYPE.IFRAME;
+    return this.type === Frame.TYPES.IFRAME;
   }
 
   /**

--- a/lib/recurly/risk/three-d-secure/strategy/adyen.js
+++ b/lib/recurly/risk/three-d-secure/strategy/adyen.js
@@ -1,7 +1,7 @@
 import loadScript from 'load-script';
 import Promise from 'promise';
 import ThreeDSecureStrategy from './strategy';
-import { TYPE } from '../../../frame';
+import { Frame } from '../../../frame';
 
 const debug = require('debug')('recurly:risk:three-d-secure:adyen');
 
@@ -134,7 +134,7 @@ export default class AdyenStrategy extends ThreeDSecureStrategy {
       redirect_url: adyenRedirectParams.url,
       ...adyenRedirectParams.data
     };
-    this.frame = recurly.Frame({ type: TYPE.IFRAME, path: '/three_d_secure/start', payload, container })
+    this.frame = recurly.Frame({ type: Frame.TYPES.IFRAME, path: '/three_d_secure/start', payload, container })
       .on('error', cause => threeDSecure.error('3ds-auth-error', { cause }))
       .on('done', results => this.emit('done', results));
   }

--- a/lib/recurly/risk/three-d-secure/strategy/sage-pay.js
+++ b/lib/recurly/risk/three-d-secure/strategy/sage-pay.js
@@ -1,5 +1,5 @@
 import ThreeDSecureStrategy from './strategy';
-import { TYPE } from '../../../frame';
+import { Frame } from '../../../frame';
 
 const debug = require('debug')('recurly:risk:three-d-secure:sage-pay');
 
@@ -35,7 +35,7 @@ export default class SagePayStrategy extends ThreeDSecureStrategy {
       three_d_secure_action_token_id: this.actionToken.id
     };
 
-    this.frame = recurly.Frame({ path: '/three_d_secure/start', payload, container, type: TYPE.IFRAME })
+    this.frame = recurly.Frame({ path: '/three_d_secure/start', payload, container, type: Frame.TYPES.IFRAME })
       .on('error', cause => threeDSecure.error('3ds-auth-error', { cause }))
       .on('done', results => this.emit('done', results));
   }

--- a/lib/recurly/risk/three-d-secure/strategy/test.js
+++ b/lib/recurly/risk/three-d-secure/strategy/test.js
@@ -1,6 +1,6 @@
 import Promise from 'promise';
 import ThreeDSecureStrategy from './strategy';
-import { TYPE } from '../../../frame';
+import { Frame } from '../../../frame';
 
 const debug = require('debug')('recurly:risk:three-d-secure:test');
 
@@ -44,7 +44,7 @@ export default class TestStrategy extends ThreeDSecureStrategy {
       const { recurly } = threeDSecure.risk;
 
       recurly.Frame({
-        type: TYPE.IFRAME,
+        type: Frame.TYPES.IFRAME,
         path: '/three_d_secure/mock',
         payload: { three_d_secure_action_token_id: actionToken.id },
         container

--- a/lib/recurly/risk/three-d-secure/strategy/wirecard.js
+++ b/lib/recurly/risk/three-d-secure/strategy/wirecard.js
@@ -1,5 +1,5 @@
 import ThreeDSecureStrategy from './strategy';
-import { TYPE } from '../../../frame';
+import { Frame } from '../../../frame';
 
 const debug = require('debug')('recurly:risk:three-d-secure:wirecard');
 
@@ -32,7 +32,7 @@ export default class WirecardStrategy extends ThreeDSecureStrategy {
       pa_req: redirectParams.pareq
     };
 
-    this.frame = recurly.Frame({ path: '/three_d_secure/start', payload, container, type: TYPE.IFRAME })
+    this.frame = recurly.Frame({ path: '/three_d_secure/start', payload, container, type: Frame.TYPES.IFRAME })
       .on('error', cause => threeDSecure.error('3ds-auth-error', { cause }))
       .on('done', results => this.emit('done', results));
   }

--- a/lib/recurly/risk/three-d-secure/strategy/worldpay.js
+++ b/lib/recurly/risk/three-d-secure/strategy/worldpay.js
@@ -1,7 +1,7 @@
 import errors from '../../../errors';
 import Promise from 'promise';
 import ThreeDSecureStrategy from './strategy';
-import { TYPE } from '../../../frame';
+import { Frame } from '../../../frame';
 
 const debug = require('debug')('recurly:risk:three-d-secure:worldpay');
 
@@ -27,7 +27,7 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
         redirect_url: 'https://secure-test.worldpay.com/shopper/3ds/ddc.html'
       },
       container: window.document.body,
-      type: TYPE.IFRAME,
+      type: Frame.TYPES.IFRAME,
       height: 0,
       width: 0
     });
@@ -81,7 +81,7 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
       three_d_secure_action_token_id: actionToken.id
     };
 
-    this.frame = recurly.Frame({ path: '/three_d_secure/start', type: TYPE.IFRAME, payload, container })
+    this.frame = recurly.Frame({ path: '/three_d_secure/start', type: Frame.TYPES.IFRAME, payload, container })
       .on('error', cause => threeDSecure.error('3ds-auth-error', { cause }))
       .on('done', results => this.emit('done', results));
   }

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -1,7 +1,7 @@
 import { applyFixtures } from './support/fixtures';
 import assert from 'assert';
 import { initRecurly, stubWindowOpen, testBed } from './support/helpers';
-import { TYPE } from '../lib/recurly/frame';
+import { Frame } from '../lib/recurly/frame'
 
 describe('Recurly.Frame', function () {
   const path = '/frame_mock';
@@ -144,7 +144,7 @@ describe('Recurly.Frame', function () {
     it('requires a container', function () {
       const { recurly } = this;
       assert.throws(() => {
-        this.frame = recurly.Frame({ path, payload, type: TYPE.IFRAME });
+        this.frame = recurly.Frame({ path, payload, type: Frame.TYPES.IFRAME });
       }, 'Invalid container. Expected HTMLElement, got undefined');
     });
 
@@ -152,7 +152,7 @@ describe('Recurly.Frame', function () {
       beforeEach(function (done) {
         const { recurly, isIE } = this;
         if (isIE) window.document.body.appendChild.restore();
-        this.frame = recurly.Frame({ path, payload, type: TYPE.IFRAME, container: testBed() });
+        this.frame = recurly.Frame({ path, payload, type: Frame.TYPES.IFRAME, container: testBed() });
         this.frame.on('done', () => done());
       });
 

--- a/test/risk/three-d-secure/strategy/adyen.test.js
+++ b/test/risk/three-d-secure/strategy/adyen.test.js
@@ -6,7 +6,7 @@ import AdyenStrategy from '../../../../lib/recurly/risk/three-d-secure/strategy/
 import actionToken from '../../../server/fixtures/tokens/action-token-adyen.json';
 import fingerprintActionToken from '../../../server/fixtures/tokens/action-token-adyen-fingerprint.json';
 import fallbackActionToken from '../../../server/fixtures/tokens/action-token-adyen-3ds1.json';
-import { TYPE } from '../../../../lib/recurly/frame';
+import { Frame } from '../../../../lib/recurly/frame'
 
 describe('AdyenStrategy', function () {
   this.ctx.fixture = 'threeDSecure';
@@ -121,7 +121,7 @@ describe('AdyenStrategy', function () {
         strategy.attach(target);
         assert(recurly.Frame.calledOnce);
         assert(recurly.Frame.calledWithMatch({
-          type: TYPE.IFRAME,
+          type: Frame.TYPES.IFRAME,
           path: '/three_d_secure/start',
           payload: {
             redirect_url: 'test-url',

--- a/test/risk/three-d-secure/strategy/test.test.js
+++ b/test/risk/three-d-secure/strategy/test.test.js
@@ -3,7 +3,7 @@ import { applyFixtures } from '../../../support/fixtures';
 import { initRecurly, testBed } from '../../../support/helpers';
 import TestStrategy from '../../../../lib/recurly/risk/three-d-secure/strategy/test';
 import actionToken from '../../../server/fixtures/tokens/action-token-test.json';
-import { TYPE } from '../../../../lib/recurly/frame';
+import { Frame } from '../../../../lib/recurly/frame';
 
 describe('TestStrategy', function () {
   this.ctx.fixture = 'threeDSecure';
@@ -34,7 +34,7 @@ describe('TestStrategy', function () {
         strategy.on('done', result => {
           assert(recurly.Frame.calledOnce);
           assert(recurly.Frame.calledWithMatch({
-            type: TYPE.IFRAME,
+            type: Frame.TYPES.IFRAME,
             path: '/three_d_secure/mock',
             payload: { three_d_secure_action_token_id: 'action-token-test' },
             container: strategy.container

--- a/test/risk/three-d-secure/strategy/wirecard.test.js
+++ b/test/risk/three-d-secure/strategy/wirecard.test.js
@@ -4,7 +4,7 @@ import { initRecurly, testBed } from '../../../support/helpers';
 import WirecardStrategy from '../../../../lib/recurly/risk/three-d-secure/strategy/wirecard';
 import actionToken from '../../../server/fixtures/tokens/action-token-wirecard.json';
 import Promise from 'promise';
-import { TYPE } from '../../../../lib/recurly/frame';
+import { Frame}  from '../../../../lib/recurly/frame';
 
 describe('WirecardStrategy', function () {
   this.ctx.fixture = 'threeDSecure';
@@ -41,7 +41,7 @@ describe('WirecardStrategy', function () {
           redirect_url: 'test-wirecard-acs-url',
           pa_req: 'test-wirecard-pa-req'
         },
-        type: TYPE.IFRAME
+        type: Frame.TYPES.IFRAME
       }));
     });
   });

--- a/test/risk/three-d-secure/strategy/worldpay.test.js
+++ b/test/risk/three-d-secure/strategy/worldpay.test.js
@@ -4,7 +4,7 @@ import { initRecurly, testBed } from '../../../support/helpers';
 import WorldpayStrategy from '../../../../lib/recurly/risk/three-d-secure/strategy/worldpay';
 import actionToken from '../../../server/fixtures/tokens/action-token-worldpay.json';
 import Promise from 'promise';
-import { TYPE } from '../../../../lib/recurly/frame';
+import { Frame } from '../../../../lib/recurly/frame';
 
 describe('WorldpayStrategy', function () {
   this.ctx.fixture = 'threeDSecure';
@@ -68,7 +68,7 @@ describe('WorldpayStrategy', function () {
           jwt,
           redirect_url: 'https://secure-test.worldpay.com/shopper/3ds/ddc.html'
         },
-        type: TYPE.IFRAME,
+        type: Frame.TYPES.IFRAME,
         height: 0,
         width: 0
       }));


### PR DESCRIPTION
I'm thinking there's a better way to implement this that doesn't involve exporting/import `TYPE`, but I don't know what that would be.

With a static property as suggested in the ticket, I wasn't able to figure how to use that outside of the class when creating an instance of Frame (i.e., `const frame = new Frame({ type: Frame.TYPES.IFRAME });` or something like `Frame({ type: this.constructor.TYPES.IFRAME });` or `Frame({ type: this.TYPES.IFRAME });`

If I'm missing something, I'm open to changing anything.