### PR TITLE
Fixes an issue with paypal incorrectly emitting a cancel event on success

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,7 @@ const staticConfig = {
     },
     FirefoxDebug: {
       base: 'Firefox',
-      flags: ['-devtools']
+      flags: ['--devtools']
     },
     VirtualBoxEdgeWin10: {
       base: 'VirtualBoxEdge',

--- a/lib/recurly/frame.js
+++ b/lib/recurly/frame.js
@@ -150,9 +150,12 @@ export class Frame extends Emitter {
 
     this.once(payload.event, res => {
       this.removeRelay();
-      if (res.error) this.emit('error', res.error);
-      else this.emit('done', res);
-      if (this.isIframe) this.destroy();
+      if (res.error) {
+        this.emit('error', res.error);
+      } else {
+        this.emit('done', res);
+      }
+      this.destroy();
     });
 
     this.url = this.recurly.url(path);
@@ -242,14 +245,17 @@ export class Frame extends Emitter {
    * @private
    */
   destroy () {
-    const { iframe } = this;
-    if (this.window) {
-      this.window.close();
-    } else if (iframe) {
+    const { iframe, window: frameWindow } = this;
+
+    if (iframe) {
       const { parentElement } = iframe;
       if (parentElement) parentElement.removeChild(iframe);
       delete this.iframe;
+    } else if (frameWindow) {
+      if (frameWindow.close) frameWindow.close();
+      this.removeWindowCloseListener();
     }
+
     this.off();
     this.removeRelay();
   }
@@ -266,17 +272,21 @@ export class Frame extends Emitter {
   }
 
   bindWindowCloseListener () {
-    const tick = setInterval(() => {
+    const tick = this.windowCloseListenerTick = setInterval(() => {
       if (!this.window) {
         return clearInterval(tick);
       }
       if (this.window.closed) {
         debug('detected frame window closure. Destroying.', this.window);
-        clearInterval(tick);
         this.emit('close');
         this.destroy();
       }
     }, 1000);
+  }
+
+  removeWindowCloseListener () {
+    const { windowCloseListenerTick: tick } = this;
+    if (tick) clearInterval(tick);
   }
 }
 

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -138,6 +138,12 @@ describe('Recurly.Frame', function () {
       frame.destroy();
       assert(newWindow.close.calledOnce);
     });
+
+    it('removes window close listener', function () {
+      sinon.spy(global, 'clearInterval');
+      this.frame.destroy();
+      assert(clearInterval.calledWith(this.frame.windowCloseListenerTick));
+    });
   });
 
   describe('when type=iframe', function () {


### PR DESCRIPTION
This fixes the issue in the title by calling `clearInterval` on the tick that polls the window when a paypal action is successful.