### PR TITLE
Checkout pricing items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
     - node_modules
 before_install:
   - bash .travis-pre.sh
-script:
-  - make lint
-  - make test-ci
 addons:
   chrome: stable
   artifacts:
@@ -19,6 +16,7 @@ addons:
       - artifacts/$TRAVIS_COMMIT
     s3_region: us-west-1
     permissions: public-read
+script: make test-ci
 env:
   global:
     - secure: U0dvpEjblZ3i+knw/cOWWgLvHUz/L9vN7Kv5VKDJ5ydvLy/1Tcueokp4hL7jhu4zwzlJto6MdFG1uKXr97zs+ETV9clYtRFBF/4YlAGs8sQcvPu4BOyH9pUJ77tnNR2ZX62wik9UFl6LmJOBpCjVkp+kh6it44QJm4Zv03Yx47w=
@@ -26,14 +24,21 @@ env:
     - secure: yIrHdkLhWtO37N24cRU71PK80zvkPzlJ1Jm+1MS3C6/icgJ8At1N/UgpBdxuBs1tlJm1O7Ahk+/MhpGWlspx9tCF7Hzw9Rj0xpKhqsvM155zgH582xNPwNebiCr/tmsH2/ELgFBBgC9sCW5luzeKx9nyuedGA4fmD2fK5Phc5EE=
     - secure: fGRo+RTDcnWNnYjSgDtHIRFrkXDxYzFrF0JaGs73ZunLXoYbJ5FclaM9+wjw8BbGEEsVbyBYMSHyy8E2Y0VRggal/XlFkKaqQQHSDVuslcM5YdAkcLC8jFSuSzP32X6cY+L9fKszFVaO+vn84lXwiQnqgpOHAtN32/eB//5Ky1s=
     - secure: m9ylFoxkeoOjBTYi7IF93Rqq95uJkL95onYJc5k1Xo2wNCDrAfvZ8cv6o70Qr/lpWqvgxPueDP6VXjxKAmSueQnx9uGKyigFCpMH4zl7+7n7l4382Eeyex2uE6kCh/lA4EjkmE3QdIW6l8YCGJD1IoHqVSKPZ67ZSdnapTgGPYQ=
-  matrix:
-    - BROWSER=chrome_headless ARTIFACTS_BUCKET=recurly-js REPORT_COVERAGE=true
-    - BROWSER=chrome
-    - BROWSER=firefox
-    - BROWSER=safari
-    - BROWSER=edge
-    - BROWSER=ie_11
-    - BROWSER=ios_12
-    - BROWSER=android_9
-    - BROWSER=android_8
-    - BROWSER=android_7
+jobs:
+  include:
+    - stage: Lint
+      script: make lint
+    - stage: Test
+      env: BROWSER=chrome_headless REPORT_COVERAGE=true
+    - env: BROWSER=chrome
+    - env: BROWSER=firefox
+    - env: BROWSER=safari
+    - env: BROWSER=edge
+    - env: BROWSER=ie_11
+    - env: BROWSER=ios_12
+    - env: BROWSER=android_9
+    - env: BROWSER=android_8
+    - env: BROWSER=android_7
+    - stage: Publish
+      env: ARTIFACTS_BUCKET=recurly-js
+      script: make build

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,13 +12,7 @@ const staticConfig = {
   port: 9876,
   colors: true,
   autoWatch: true,
-  browsers: [
-    'ChromeHeadless'
-    // 'ChromeDebug'
-    // 'FirefoxDebug'
-    // 'VirtualBoxIE11Win7'
-    // 'VirtualBoxEdgeWin10'
-  ],
+  browsers: [process.env.BROWSER || 'ChromeHeadless'],
   singleRun: true,
   concurrency: Infinity,
   browserDisconnectTimeout: 800000,
@@ -34,15 +28,11 @@ const staticConfig = {
       base: 'Firefox',
       flags: ['--devtools']
     },
-    VirtualBoxEdgeWin10: {
-      base: 'VirtualBoxEdge',
-      keepAlive: true,
-      uuid: 'fb87b330-a1dc-4d6d-ac5b-e669912f1a4f'
-    },
     VirtualBoxIE11Win7: {
       base: 'VirtualBoxIE11',
       keepAlive: true,
-      vmName: 'IE11 - Win7'
+      vmName: 'IE11 - Win7',
+      uuid: '9c440145-fbea-49ea-a22f-4162bfaaaa2f'
     }
   },
   client: {
@@ -62,8 +52,7 @@ const staticConfig = {
 };
 
 function runner (config) {
-  const logLevel = config.LOG_INFO;
-  config.set(Object.assign({}, staticConfig, { logLevel }));
+  config.set(Object.assign({}, staticConfig, { logLevel: config.LOG_INFO }));
 }
 
 const server = require('./test/server');

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -8,6 +8,7 @@ import errors from './recurly/errors';
 import { bankAccount } from './recurly/bank-account';
 import coupon from './recurly/coupon';
 import giftcard from './recurly/giftcard';
+import item from './recurly/item';
 import plan from './recurly/plan';
 import tax from './recurly/tax';
 import version from './recurly/version';
@@ -352,6 +353,7 @@ Recurly.prototype.coupon = coupon;
 Recurly.prototype.Frame = Frame;
 Recurly.prototype.giftCard = giftcard;
 Recurly.prototype.giftcard = giftcard; // DEPRECATED
+Recurly.prototype.item = item;
 Recurly.prototype.PayPal = PayPal;
 Recurly.prototype.paypal = deprecatedPaypal;
 Recurly.prototype.plan = plan;

--- a/lib/recurly/errors.js
+++ b/lib/recurly/errors.js
@@ -91,6 +91,18 @@ const ERRORS = [
     classification: 'merchant'
   },
   {
+    code: 'invalid-item-currency',
+    message: c => `The requested item (${c.itemCode}) does not support the requested currency: ${c.currency}.`,
+    classification: 'merchant'
+  },
+  {
+    code: 'item-code-not-allowed',
+    message: `An itemCode may only be specified when creating a new adjustment. To replace an
+              existing adjustment, first remove it and then create a new adjustment with this
+              itemCode.`,
+    classification: 'merchant'
+  },
+  {
     code: 'unremovable-item',
     message: 'The given item cannot be removed.',
     classification: 'merchant'

--- a/lib/recurly/errors.js
+++ b/lib/recurly/errors.js
@@ -96,13 +96,6 @@ const ERRORS = [
     classification: 'merchant'
   },
   {
-    code: 'item-code-not-allowed',
-    message: `An itemCode may only be specified when creating a new adjustment. To replace an
-              existing adjustment, first remove it and then create a new adjustment with this
-              itemCode.`,
-    classification: 'merchant'
-  },
-  {
     code: 'unremovable-item',
     message: 'The given item cannot be removed.',
     classification: 'merchant'

--- a/lib/recurly/item.js
+++ b/lib/recurly/item.js
@@ -19,5 +19,5 @@ export default function item ({ itemCode } = {}) {
     throw errors('invalid-option', { name: 'itemCode', expect: 'a String' });
   }
 
-  return this.request.get({ route: `/items/${itemCode}` });
+  return this.request.get({ route: `/items/${itemCode}`, cached: true });
 }

--- a/lib/recurly/item.js
+++ b/lib/recurly/item.js
@@ -1,0 +1,23 @@
+import errors from './errors';
+
+const debug = require('debug')('recurly:item');
+
+/**
+ * Item
+ *
+ * Retrieves item pricing info based on an item code.
+ *
+ * @param {Object} options
+ * @param {String} options.itemCode
+ * @return {Promise}
+ */
+
+export default function item ({ itemCode } = {}) {
+  debug(itemCode);
+
+  if (typeof itemCode !== 'string') {
+    throw errors('invalid-option', { name: 'itemCode', expect: 'a String' });
+  }
+
+  return this.request.get({ route: `/items/${itemCode}` });
+}

--- a/lib/recurly/pricing/checkout/attachment.js
+++ b/lib/recurly/pricing/checkout/attachment.js
@@ -127,40 +127,43 @@ export default class Attachment extends Emitter {
         .reprice();
     }))
       .then(() => {
-      // Adjustments
+        // Adjustments
         if (!elems.adjustment) return;
         return Promise.all(elems.adjustment.map(adjustmentElem => {
           const id = dom.data(adjustmentElem, 'recurlyAdjustment');
+          const itemCode = dom.data(adjustmentElem, 'recurlyAdjustmentItemCode');
           const amount = dom.data(adjustmentElem, 'recurlyAdjustmentAmount');
-          const quantity = dom.value(adjustmentElem);
+          const quantity = dom.value(adjustmentElem) || 0;
           const currency = dom.data(adjustmentElem, 'recurlyAdjustmentCurrency');
           const taxCode = dom.data(adjustmentElem, 'recurlyAdjustmentTaxCode');
           const taxExempt = dom.data(adjustmentElem, 'recurlyAdjustmentTaxExempt');
 
-          return this.pricing.adjustment({ id, amount, quantity, currency, taxCode, taxExempt });
+          return this.pricing.adjustment({
+            id, itemCode, amount, quantity, currency, taxCode, taxExempt
+          });
         }));
       })
       .then(() => {
-      // Currency
+        // Currency
         if (!elems.currency) return;
         return this.pricing.currency(dom.value(elems.currency));
       })
       .then(() => {
-      // Coupon
+        // Coupon
         if (!elems.coupon) return;
         return this.pricing
           .coupon(dom.value(elems.coupon).trim())
           .then(null, ignoreNotFound);
       })
       .then(() => {
-      // Gift card
+        // Gift card
         if (!elems.gift_card) return;
         return this.pricing
           .giftCard(dom.value(elems.gift_card).trim())
           .then(null, ignoreNotFound);
       })
       .then(() => {
-      // Address
+        // Address
         if (elems.country || elems.postal_code) {
           return this.pricing.address({
             country: dom.value(elems.country),
@@ -169,7 +172,7 @@ export default class Attachment extends Emitter {
         }
       })
       .then(() => {
-      // Shipping Address
+        // Shipping Address
         if (elems['shipping_address.country'] || elems['shipping_address.postal_code']) {
           return this.pricing.shippingAddress({
             country: dom.value(elems['shipping_address.country']),
@@ -178,7 +181,7 @@ export default class Attachment extends Emitter {
         }
       })
       .then(() => {
-      // Taxes
+        // Taxes
         let taxParams = {};
         if (elems['tax_amount.now'] || elems['tax_amount.next']) {
           taxParams.amount = {

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -34,7 +34,7 @@ const debug = require('debug')('recurly:pricing:checkout-pricing');
  * checkoutPricing.on('change', price => console.log(price));
  * checkoutPricing
  *   .currency('USD')
- *   .subscription(recurly.pricing.Subscription().plan('my-plan').done())
+ *   .subscription(recurly.Pricing.Subscription().plan('my-plan').done())
  *   .adjustment({ itemCode: 'my-item-code', quantity: 2 })
  *   .address({ country: 'US', postalCode: '94110' })
  *   .coupon('my-coupon-code')
@@ -246,35 +246,22 @@ export default class CheckoutPricing extends Pricing {
         }
       }
 
-      let adjustment = {};
-
-      if (existingAdjustment) {
-        if (itemCode) return this.error(errors('item-code-not-allowed'), reject, 'adjustment');
-
-        if (typeof amount !== 'undefined') adjustment.amount = amount;
-        if (typeof currency !== 'undefined') adjustment.currency = currency;
-        if (typeof quantity !== 'undefined') adjustment.quantity = parseInt(quantity, 10);
-
-        if (!existingAdjustment.itemCode) {
-          if (typeof taxCode !== 'undefined') adjustment.taxCode = taxCode;
-          if (typeof taxExempt !== 'undefined') adjustment.taxExempt = !!taxExempt;
-        }
-
-        adjustment = Object.assign(existingAdjustment, adjustment);
-        return this.resolveAndEmit('set.adjustment', adjustment, resolve);
+      if (existingAdjustment && existingAdjustment.itemCode && !itemCode) {
+        itemCode = existingAdjustment.itemCode;
       }
-
-      currency = currency || this.items.currency;
 
       new Promise((resolve, reject) => {
         if (!itemCode) return resolve();
         return recurly.item({ itemCode }).then(item => {
+          const expectedCurrency = currency
+                                || (existingAdjustment && existingAdjustment.currency)
+                                || this.items.currency;
           if (typeof amount === 'undefined') {
-            const itemPrice = find(item.currencies, c => c.currency_code === currency);
+            const itemPrice = find(item.currencies, c => c.currency_code === expectedCurrency);
             if (itemPrice) {
               amount = itemPrice.unit_amount;
             } else {
-              return reject(errors('invalid-item-currency', { itemCode, currency }));
+              return reject(errors('invalid-item-currency', { itemCode, currency: expectedCurrency }));
             }
           }
           taxCode = item.tax_code;
@@ -283,14 +270,38 @@ export default class CheckoutPricing extends Pricing {
         }, reject);
       })
         .then(() => {
-          quantity = parseInt(quantity, 10);
-          if (isNaN(quantity)) quantity = 1;
-          taxExempt = !!taxExempt;
+          // New adjustment defaults
+          if (!existingAdjustment) {
+            currency = currency || this.items.currency;
+            quantity = coerceAdjustmentQuantity(quantity);
+            taxExempt = !!taxExempt;
+          }
 
           return { amount, quantity, id, currency, taxExempt, taxCode, itemCode };
         })
         .then(adjustment => {
-          this.items.adjustments.push(adjustment);
+          if (existingAdjustment) {
+            if (typeof amount === 'undefined') delete adjustment.amount;
+            if (typeof currency === 'undefined') delete adjustment.currency;
+            if (typeof quantity === 'undefined') {
+              delete adjustment.quantity;
+            } else {
+              quantity = coerceAdjustmentQuantity(quantity);
+            }
+
+            if (existingAdjustment.itemCode || typeof taxCode === 'undefined') {
+              delete adjustment.taxCode;
+            }
+
+            if (existingAdjustment.itemCode || typeof taxExempt === 'undefined') {
+              delete  adjustment.taxExempt;
+            }
+
+            adjustment = Object.assign(existingAdjustment, adjustment);
+          } else {
+            this.items.adjustments.push(adjustment);
+          }
+
           this.resolveAndEmit('set.adjustment', adjustment, resolve);
         })
         .catch(err => {
@@ -522,4 +533,10 @@ export default class CheckoutPricing extends Pricing {
       }
     }));
   }
+}
+
+function coerceAdjustmentQuantity (quantity) {
+  quantity = parseInt(quantity, 10);
+  if (isNaN(quantity)) quantity = 1;
+  return quantity;
 }

--- a/lib/recurly/pricing/checkout/index.js
+++ b/lib/recurly/pricing/checkout/index.js
@@ -16,7 +16,32 @@ import Attachment from './attachment';
 const debug = require('debug')('recurly:pricing:checkout-pricing');
 
 /**
- * checkoutPricing = recurly.Pricing.Checkout();
+ * CheckoutPricing
+ *
+ * Constructs a pricing model for a checkout purchase. Call methods
+ * on an instance to add or remove items from the pricing model, and
+ * listen for changes to the price.
+ *
+ * This class allows you to provide basic details about a checkout purchase,
+ * such as plan code, item code, and address, and receive detailed pricing
+ * information about the overall purchase, including item costs, tax estimates,
+ * complex discounting, and currency changes.
+ *
+ * Example
+ *
+ * ```
+ * const checkoutPricing = recurly.Pricing.Checkout();
+ * checkoutPricing.on('change', price => console.log(price));
+ * checkoutPricing
+ *   .currency('USD')
+ *   .subscription(recurly.pricing.Subscription().plan('my-plan').done())
+ *   .adjustment({ itemCode: 'my-item-code', quantity: 2 })
+ *   .address({ country: 'US', postalCode: '94110' })
+ *   .coupon('my-coupon-code')
+ *   .done();
+ * ```
+ *
+ * @class
  */
 
 export default class CheckoutPricing extends Pricing {
@@ -181,24 +206,35 @@ export default class CheckoutPricing extends Pricing {
   }
 
   /**
+   * @typedef {Object} CheckoutPricing~Adjustment
+   *
+   * @property {String}  [itemCode] item code reference. If provided,
+   *                                the amount and tax properties will be populated
+   *                                from the given item. an itemCode may not be used to
+   *                                modify an adjustment in-place.
+   * @property {Number}  [amount] in unit price (1.0 for USD, etc)
+   * @property {Number}  [quantity=1] number of units
+   * @property {String}  [id=uid()] unique identifier. Use this value to modify an
+   *                                adjustment in-place
+   * @property {String}  [currency=this.items.currency] currency code
+   * @property {Boolean} [taxExempt=false] whether this adjustment is tax exempt
+   * @property {String}  [taxCode] taxation code
+   */
+
+  /**
    * Adds a one-time charge or credit a.k.a. adjustment
    *
-   * @param {Object}  adjustment
-   * @param {Number}  adjustment.amount in unit price (1.0 for USD, etc)
-   * @param {Number}  [adjustment.quantity=1] number of units
-   * @param {String}  [adjustment.id=uid()] unique identifier
-   * @param {String}  [adjustment.currency=this.items.currency] currency code
-   * @param {Boolean} [adjustment.taxExempt=false] whether this adjustment is tax exempt
-   * @param {String}  [adjustment.taxCode] taxation code
+   * @param {CheckoutPricing~Adjustment} adjustment
    * @return {PricingPromise}
    * @public
    */
-  adjustment ({ amount, quantity, id = uid(), currency, taxExempt, taxCode }) {
+  adjustment ({ itemCode = null, amount, quantity, id = uid(), currency, taxExempt, taxCode }) {
+    const { recurly } = this;
     return new PricingPromise((resolve, reject) => {
       let existingAdjustment = find(this.items.adjustments, a => a.id === id);
       let validateAmount = true;
 
-      if (existingAdjustment && typeof amount === 'undefined') {
+      if (itemCode || (existingAdjustment && typeof amount === 'undefined')) {
         validateAmount = false;
       }
 
@@ -213,27 +249,53 @@ export default class CheckoutPricing extends Pricing {
       let adjustment = {};
 
       if (existingAdjustment) {
-        // Only pick present attributes
+        if (itemCode) return this.error(errors('item-code-not-allowed'), reject, 'adjustment');
+
         if (typeof amount !== 'undefined') adjustment.amount = amount;
         if (typeof currency !== 'undefined') adjustment.currency = currency;
         if (typeof quantity !== 'undefined') adjustment.quantity = parseInt(quantity, 10);
-        if (typeof taxExempt !== 'undefined') adjustment.taxExempt = taxExempt;
-        if (typeof taxCode !== 'undefined') adjustment.taxCode = taxCode;
 
-        Object.assign(existingAdjustment, adjustment);
-      } else {
-        // Adjustment defaults
-        quantity = parseInt(quantity, 10);
-        if (isNaN(quantity)) quantity = 1;
-        currency = currency || this.items.currency;
-        taxExempt = !!taxExempt;
+        if (!existingAdjustment.itemCode) {
+          if (typeof taxCode !== 'undefined') adjustment.taxCode = taxCode;
+          if (typeof taxExempt !== 'undefined') adjustment.taxExempt = !!taxExempt;
+        }
 
-        adjustment = { amount, quantity, id, currency, taxExempt, taxCode };
-
-        this.items.adjustments.push(adjustment);
+        adjustment = Object.assign(existingAdjustment, adjustment);
+        return this.resolveAndEmit('set.adjustment', adjustment, resolve);
       }
 
-      this.resolveAndEmit('set.adjustment', adjustment, resolve);
+      currency = currency || this.items.currency;
+
+      new Promise((resolve, reject) => {
+        if (!itemCode) return resolve();
+        return recurly.item({ itemCode }).then(item => {
+          if (typeof amount === 'undefined') {
+            const itemPrice = find(item.currencies, c => c.currency_code === currency);
+            if (itemPrice) {
+              amount = itemPrice.unit_amount;
+            } else {
+              return reject(errors('invalid-item-currency', { itemCode, currency }));
+            }
+          }
+          taxCode = item.tax_code;
+          taxExempt = item.tax_exempt;
+          resolve();
+        }, reject);
+      })
+        .then(() => {
+          quantity = parseInt(quantity, 10);
+          if (isNaN(quantity)) quantity = 1;
+          taxExempt = !!taxExempt;
+
+          return { amount, quantity, id, currency, taxExempt, taxCode, itemCode };
+        })
+        .then(adjustment => {
+          this.items.adjustments.push(adjustment);
+          this.resolveAndEmit('set.adjustment', adjustment, resolve);
+        })
+        .catch(err => {
+          this.error(err, reject, 'adjustment');
+        });
     }, this);
   }
 

--- a/test/giftcard.test.js
+++ b/test/giftcard.test.js
@@ -1,7 +1,6 @@
-import each from 'lodash.foreach';
 import assert from 'assert';
-import {Recurly} from '../lib/recurly';
-import {apiTest} from './support/helpers';
+import { Recurly } from '../lib/recurly';
+import { apiTest } from './support/helpers';
 
 apiTest(function (requestMethod) {
   describe('Recurly.giftcard (' + requestMethod + ')', function () {

--- a/test/item.test.js
+++ b/test/item.test.js
@@ -1,0 +1,72 @@
+import assert from 'assert';
+import { Recurly } from '../lib/recurly';
+import { apiTest, initRecurly } from './support/helpers';
+
+apiTest((requestMethod) => {
+  describe(`Recurly.item (${requestMethod})`, () => {
+    beforeEach(function () {
+      this.sandbox = sinon.createSandbox();
+      this.recurly = initRecurly({ cors: requestMethod === 'cors' });
+      this.valid = { itemCode: 'basic-item' };
+      this.invalid = { itemCode: 'invalid' };
+    });
+
+    it('requires an itemCode', function () {
+      const { recurly } = this;
+      assert.throws(() => recurly.item(), 'Option itemCode must be a String');
+    });
+
+    it('requires Recurly.configure', function (done) {
+      const { sandbox, valid } = this;
+      const recurly = new Recurly();
+      const stub = sandbox.stub();
+      recurly.item(valid)
+        .then(stub)
+        .catch(err => {
+          assert(stub.notCalled);
+          assert.strictEqual(err.code, 'not-configured');
+          done();
+        });
+    });
+
+    describe('when given an invalid itemCode', function () {
+      it('rejects with an error', function (done) {
+        const { invalid, recurly, sandbox } = this;
+        const stub = sandbox.stub();
+        recurly.item(invalid)
+          .then(stub)
+          .catch(err => {
+            assert(stub.notCalled);
+            assert.strictEqual(err.code, 'not-found');
+            assert.strictEqual(err.message, "Couldn't find Item with item_code=invalid");
+            done();
+          });
+      });
+    });
+
+    describe('when given a valid itemCode', function () {
+      it('resolves with an item', function (done) {
+        const { recurly, sandbox, valid } = this;
+        const stub = sandbox.stub();
+        recurly.item(valid)
+          .catch(stub)
+          .then(item => {
+            assert(stub.notCalled);
+            assert.strictEqual(item.code, 'basic-item');
+            assert.strictEqual(item.name, 'Basic Item');
+            assert.strictEqual(item.tax_code, null);
+            assert.strictEqual(item.tax_exempt, true);
+            assert(Array.isArray(item.currencies));
+            assert.strictEqual(item.currencies.length, 2);
+            assert.strictEqual(item.currencies[0].currency_code, 'CAD');
+            assert.strictEqual(item.currencies[0].currency_symbol, '$');
+            assert.strictEqual(item.currencies[0].unit_amount, 60.0);
+            assert.strictEqual(item.currencies[1].currency_code, 'USD');
+            assert.strictEqual(item.currencies[1].currency_symbol, '$');
+            assert.strictEqual(item.currencies[1].unit_amount, 40.0);
+            done();
+          });
+      });
+    });
+  });
+});

--- a/test/server/fixtures/items/basic-item-eur.json
+++ b/test/server/fixtures/items/basic-item-eur.json
@@ -1,0 +1,13 @@
+{
+  "code": "basic-item",
+  "name": "Basic Item",
+  "tax_code": null,
+  "tax_exempt": true,
+  "currencies": [
+    {
+      "currency_code": "EUR",
+      "currency_symbol": "€",
+      "unit_amount": 100.0
+    }
+  ]
+}

--- a/test/server/fixtures/items/basic-item.json
+++ b/test/server/fixtures/items/basic-item.json
@@ -1,0 +1,18 @@
+{
+  "code": "basic-item",
+  "name": "Basic Item",
+  "tax_code": null,
+  "tax_exempt": true,
+  "currencies": [
+    {
+      "currency_code": "CAD",
+      "currency_symbol": "$",
+      "unit_amount": 60.0
+    },
+    {
+      "currency_code": "USD",
+      "currency_symbol": "$",
+      "unit_amount": 40.0
+    }
+  ]
+}

--- a/test/server/fixtures/items/invalid.json
+++ b/test/server/fixtures/items/invalid.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "not-found",
+    "message": "Couldn't find Item with item_code=invalid"
+  }
+}

--- a/test/server/fixtures/plans/invalid.json
+++ b/test/server/fixtures/plans/invalid.json
@@ -1,6 +1,6 @@
 {
   "error": {
-    "code": "not_found",
+    "code": "not-found",
     "message": "Couldn't find Plan with plan_code = invalid"
   }
 }

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -25,6 +25,7 @@ app.use(route.get('/events', ok));
 app.use(route.post('/events', ok));
 app.use(route.get('/fraud_data_collector', json));
 app.use(route.get('/gift_cards/:id', json));
+app.use(route.get('/items/:id', json));
 app.use(route.get('/plans/:plan_id', json));
 app.use(route.get('/plans/:plan_id/coupons/:id', json));
 app.use(route.get('/risk/preflights', json));


### PR DESCRIPTION
`CheckoutPricing#adjustment` will now accept an `itemCode`, which Recurly.js will use to retrieve price information when constructing an adjustment. Overrides are accepted for amount.

When modifying an existing adjustment that was created with an `itemCode`, the `taxCode` and `taxExempt` properties may not be modified.

Bonus: Improves documentation of `CheckoutPricing` class