### PR TITLE
Add new Discover BINs

### DIFF
--- a/lib/recurly/validate.js
+++ b/lib/recurly/validate.js
@@ -15,8 +15,8 @@ const debug = require('debug')('recurly:validate');
 const TYPES = [
   {
     type: 'discover',
-    pattern: /^(6011|622|64[4-9]|65)/,
-    lengths: [16]
+    pattern: /^(3[0689]|6011|621094|62[24568]|64[4-9]|65|81[0-7])/,
+    lengths: [14, 15, 16, 17, 18, 19]
   },
   {
     type: 'master',

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -38,6 +38,15 @@ describe('Recurly.validate', function () {
       assert(type === 'visa');
     });
 
+    it('should parse discover', function () {
+      assert(recurly.validate.cardType('3050990900242198') === 'discover');
+      assert(recurly.validate.cardType('36003010814263') === 'discover');
+      assert(recurly.validate.cardType('6011111111111117') === 'discover');
+      assert(recurly.validate.cardType('6011000990139424') === 'discover');
+      assert(recurly.validate.cardType('6229252986142899') === 'discover');
+      assert(recurly.validate.cardType('8131917256371926354') === 'discover');
+    });
+
     it('should parse mastercard', function () {
       assert(recurly.validate.cardType('5454545454545454') === 'master');
       assert(recurly.validate.cardType('5555555555554444') === 'master');


### PR DESCRIPTION
**Description**:

Add new Discover BINs:
https://www.discoverglobalnetwork.com/downloads/IPP_VAR_Compliance.pdf

**Impact**:

* New Discover card number ranges supported
* CC numbers may be as long at 19 digits

**Testing**:

* Ensure that all credit card number fields can accept up to 19 digits plus 4 spaces. (Note that the card itself may be rejected by the payment gateway for excessive length...)
* Ensure that all Discover card number ranges are recognized by `recurly.js`.

A few random credit card numbers you can use:

* 3642114894729353156
 * 3006328989305540860
 * 6011780540223945424
 * 6210947425951487417
 * 6221279415221686517
 * 6221651960770601237
 * 6229599417949687204
 * 6285961264133421617
 * 6459900460534704497
 * 6583963952116788557
 * 8125064527526848810
 * 8171136375604275463