### PR TITLE
Fixes HostedFields reset on re-configuration preceding initialization

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -315,11 +315,17 @@ export class Recurly extends Emitter {
     // do not match chosen selectors, reset
     let reset = (
       this.hostedFields
-      && this.readyState > 1
+      && this.readyState > 0
       && !this.hostedFields.integrityCheck(this.config.fields)
     );
 
     if (reset) {
+      // If we are between states 1 and 2, we must abandon the advancement listeners
+      if (this.readyState === 1) {
+        this.off('hostedFields:ready');
+        this.off('hostedFields:state:change');
+        this.off('hostedField:submit');
+      }
       this.readyState = 0;
       this.hostedFields.destroy();
     }

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -25,7 +25,6 @@ export class HostedFields extends Emitter {
     this.fields = [];
     this.errors = [];
     this.initQueue = [];
-    this.readyState = 0;
     this.recurly = recurly;
     this.configure(recurly.sanitizedConfig);
     this.inject();
@@ -115,7 +114,6 @@ export class HostedFields extends Emitter {
     debug('destroying HostedFields');
     this.off();
     this.ready = false;
-    this.readyState = 0;
     this.fields.forEach(field => field.destroy());
     if (this.bus) this.bus.remove(this);
     this.fields = [];

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -2,7 +2,7 @@ import each from 'lodash.foreach';
 import clone from 'component-clone';
 import assert from 'assert';
 import combinations from 'combinations';
-import { initRecurly, testBed } from './support/helpers';
+import { initRecurly, nextTick, testBed } from './support/helpers';
 import { applyFixtures } from './support/fixtures';
 import { Recurly } from '../lib/recurly';
 
@@ -266,17 +266,17 @@ describe('Recurly.configure', function () {
       const numberOne = testBed().querySelector('#number-1');
       const numberTwo = testBed().querySelector('#number-2');
 
-      configureRecurly(recurly, '1', () => {
+      configureRecurly(recurly, '1', () => nextTick(() => {
         assert.strictEqual(numberOne.children.length, 1);
         assert.strictEqual(numberTwo.children.length, 0);
         assert(numberOne.querySelector('iframe') instanceof HTMLIFrameElement);
-        configureRecurly(recurly, '2', () => {
+        configureRecurly(recurly, '2', () => nextTick(() => {
           assert.strictEqual(numberOne.children.length, 0);
           assert.strictEqual(numberTwo.children.length, 1);
           assert(numberTwo.querySelector('iframe') instanceof HTMLIFrameElement);
           done();
-        });
-      });
+        }));
+      }));
     });
 
     function configureRecurly (recurly, index, done) {


### PR DESCRIPTION
**Summary**
- Fixes #570
- When `recurly.configure` was called during readyState 1, it was not
  possible to reset hosted fields.

**Scenario**
- `recurly.configure`[call 1] instantiates `recurly.hostedFields`. The fields are created.
- the fields are removed from the DOM prior to emission of the ready message
  - the advancement listener does not increment `recurly.readyState`, which remains `1`
- `recurly.configure`[call 2 and on] is called, and the reset routine is bypassed due to incompatible readyState

**Solution**
- This allows reset to occur at `readyState > 0`, essentially any time the hostedFields have begun initialization.
- If, during reset, the current readyState is 1, the awaiting listeners are abandoned in order to prevent the stale advancement listener from interfering with the new readiness state to be generated post-reset