### PR TITLE
Fixes discount calculations on free trial subscriptions with a single-use coupon

### DIFF
--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -208,7 +208,7 @@ export default class Calculations {
       this.price.next.discount = Math.min(discountableNext, coupon.discount.amount[this.items.currency]);
     }
 
-    if (coupon.single_use) this.price.next.discount = 0;
+    if (coupon.single_use && this.price.now.discount > 0) this.price.next.discount = 0;
   }
 
   /**

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -2,7 +2,7 @@ import each from 'lodash.foreach';
 import clone from 'component-clone';
 import assert from 'assert';
 import combinations from 'combinations';
-import { initRecurly, testBed } from './support/helpers';
+import { initRecurly, nextTick, testBed } from './support/helpers';
 import { applyFixtures } from './support/fixtures';
 import { Recurly } from '../lib/recurly';
 
@@ -266,17 +266,17 @@ describe('Recurly.configure', function () {
       const numberOne = testBed().querySelector('#number-1');
       const numberTwo = testBed().querySelector('#number-2');
 
-      configureRecurly(recurly, '1', () => {
+      configureRecurly(recurly, '1', () => nextTick(() => {
         assert.strictEqual(numberOne.children.length, 1);
         assert.strictEqual(numberTwo.children.length, 0);
         assert(numberOne.querySelector('iframe') instanceof HTMLIFrameElement);
-        configureRecurly(recurly, '2', () => {
+        configureRecurly(recurly, '2', () => nextTick(() => {
           assert.strictEqual(numberOne.children.length, 0);
           assert.strictEqual(numberTwo.children.length, 1);
           assert(numberTwo.querySelector('iframe') instanceof HTMLIFrameElement);
           done();
-        });
-      });
+        }));
+      }));
     });
 
     function configureRecurly (recurly, index, done) {

--- a/test/pricing/checkout/checkout.test.js
+++ b/test/pricing/checkout/checkout.test.js
@@ -1124,7 +1124,7 @@ describe('CheckoutPricing', function () {
 
           // Subscription with a free trial
           beforeEach(function (done) {
-            subscriptionPricingFactory('intermediate', this.recurly, sub => {
+            subscriptionPricingFactory('free-trial', this.recurly, sub => {
               this.subscriptionPricingExampleFour = sub;
               done();
             });

--- a/test/pricing/subscription/subscription.test.js
+++ b/test/pricing/subscription/subscription.test.js
@@ -124,7 +124,7 @@ describe('Recurly.Pricing.Subscription', function () {
 
     it('should append 20 pct. of 49.00 to have a correct tax of $9.80', function (done) {
       this.pricing
-        .plan('intermediate', { quantity: 1 })
+        .plan('free-trial', { quantity: 1 })
         .address({
           country: 'GB'
         })
@@ -458,7 +458,7 @@ describe('Recurly.Pricing.Subscription', function () {
 
     it('should apply a trial extension coupon to a plan with a trial period', function (done) {
       this.pricing
-        .plan('intermediate', { quantity: 1 })
+        .plan('free-trial', { quantity: 1 })
         .address({
           country: 'US',
           postal_code: 'NoTax'
@@ -548,6 +548,36 @@ describe('Recurly.Pricing.Subscription', function () {
           done();
         })
         .done();
+    });
+
+    describe('when the plan has a free trial period with a set-up fee', () => {
+      it('applies single-use discounts to the setup fee', function () {
+        return this.pricing
+          .plan('free-trial')
+          .coupon('coop-single-use')
+          .reprice()
+          .then(price => {
+            assert.strictEqual(price.now.discount, '2.00');
+            assert.strictEqual(price.next.discount, '0.00');
+            assert.strictEqual(price.now.total, '0.00');
+            assert.strictEqual(price.next.total, '49.00');
+          });
+      });
+    });
+
+    describe('when the plan has a free trial period and no set-up fee', () => {
+      it('applies single-use discounts to the price next period', function () {
+        return this.pricing
+          .plan('free-trial-no-setup')
+          .coupon('coop-single-use')
+          .reprice()
+          .then(price => {
+            assert.strictEqual(price.now.discount, '0.00');
+            assert.strictEqual(price.next.discount, '20.00');
+            assert.strictEqual(price.now.total, '0.00');
+            assert.strictEqual(price.next.total, '29.00');
+          });
+      });
     });
 
     describe('when the plan is changed', () => {

--- a/test/server/fixtures/plans/free-trial-no-setup.json
+++ b/test/server/fixtures/plans/free-trial-no-setup.json
@@ -1,6 +1,6 @@
 {
-  "code": "intermediate",
-  "name": "Intermediate",
+  "code": "free-trial-no-setup",
+  "name": "Free trial without a setup fee",
   "period": {
     "interval": "months",
     "length": 1
@@ -11,8 +11,8 @@
   },
   "price": {
     "USD": {
-      "setup_fee": 2.0,
-      "unit_amount": 49.00
+      "setup_fee": 0.0,
+      "unit_amount": 49.0
     }
   },
   "addons": [{

--- a/test/server/fixtures/plans/free-trial.json
+++ b/test/server/fixtures/plans/free-trial.json
@@ -1,0 +1,29 @@
+{
+  "code": "free-trial",
+  "name": "Free trial",
+  "period": {
+    "interval": "months",
+    "length": 1
+  },
+  "trial": {
+    "interval": "days",
+    "length": 7
+  },
+  "price": {
+    "USD": {
+      "setup_fee": 2.0,
+      "unit_amount": 49.00
+    }
+  },
+  "addons": [{
+    "name": "Snarf",
+    "code": "snarf",
+    "quantity": 1,
+    "price": {
+      "USD": {
+        "unit_amount": 1.0
+      }
+    }
+  }],
+  "tax_exempt": false
+}


### PR DESCRIPTION
**Summary**
- Fixes #572
- Adds test scenarios for applying a single-use fixed coupon to
  (a) a free trial subscription with a setup fee
  (b) a free trial subscription without a setup fee

**Situation**
- When pricing a subscription with a free trial plan with no setup fee
- Apply a fixed amount single-use coupon. Since the first invoice will
  be zero, the coupon should discount the next invoice. This second
  invoice was not being discounted.

**Solution**
- The next period discount should only be zeroed out if the coupon is
  both single_use and has had no discount effect on the first period
  discount