### PR TITLE
Adds support for tokenizing IBAN Bank accounts

### DIFF
--- a/lib/recurly/bank-account.js
+++ b/lib/recurly/bank-account.js
@@ -22,6 +22,7 @@ export const bankAccount = {
 const FIELDS = [
   'account_number',
   'account_number_confirmation',
+  'iban',
   'routing_number',
   'name_on_account',
   'account_type',
@@ -79,8 +80,12 @@ function token (options, done) {
     }));
   }
 
+  if ('iban' in inputs) {
+    inputs.type = 'iban_bank_account';
+  }
+
   this.request.post({
-    route: '/token',
+    route: '/tokens',
     data: inputs,
     done: (err, res) => {
       if (err) return done(err);

--- a/lib/recurly/validate.js
+++ b/lib/recurly/validate.js
@@ -74,6 +74,15 @@ const BANK_ACCOUNT_REQUIRED_FIELDS = [
   'country'
 ];
 
+/**
+ * Fields required by IBAN bank account tokenization
+ * @type {Array}
+ */
+const IBAN_BANK_ACCOUNT_REQUIRED_FIELDS = [
+  'iban',
+  'name_on_account',
+];
+
 export const publicMethods = { cardNumber, cardType, expiry, cvv };
 
 /**
@@ -206,21 +215,28 @@ export function validateCardInputs (recurly, inputs) {
  */
 export function validateBankAccountInputs (inputs) {
   const format = formatFieldValidationError;
+  let required = [];
   let errors = [];
 
-  each(BANK_ACCOUNT_REQUIRED_FIELDS, function (field){
-    if (!inputs[field]) {
-      errors.push(format(field, BLANK));
-    } else if (typeof inputs[field] !== 'string') {
-      errors.push(format(field, INVALID));
+  if ('iban' in inputs) {
+    required = IBAN_BANK_ACCOUNT_REQUIRED_FIELDS;
+  } else {
+    required = BANK_ACCOUNT_REQUIRED_FIELDS;
+
+    if (inputs.account_number !== inputs.account_number_confirmation) {
+      errors.push(format('account_number_confirmation', DOES_NOT_MATCH));
+    }
+  }
+
+  required.forEach(name => {
+    if (!inputs[name]) {
+      errors.push(format(name, BLANK));
+    } else if (typeof inputs[name] !== 'string') {
+      errors.push(format(name, INVALID));
     }
   });
 
-  if (inputs.account_number !== inputs.account_number_confirmation) {
-    errors.push(format('account_number_confirmation', DOES_NOT_MATCH));
-  }
-
-  debug('validate errors', errors);
+  debug('bank account validate errors', errors);
 
   return errors;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9060,6 +9060,15 @@
         }
       }
     },
+    "koa-override": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/koa-override/-/koa-override-3.0.0.tgz",
+      "integrity": "sha512-w2rWCfapbQUZ8TrRBarj6iwryCTooEcdw9lr1hYC1q4FnaCZcAOhpjB1VpqtbODALVMgY3JGlzLSeYRXc5Ky0Q==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2"
+      }
+    },
     "koa-qs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/koa-qs/-/koa-qs-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "koa-json": "^2.0.2",
     "koa-jsonp": "^2.0.2",
     "koa-logger": "^3.2.1",
+    "koa-override": "^3.0.0",
     "koa-qs": "^2.0.0",
     "koa-route": "^3.2.0",
     "lodash.after": "^4.0.4",

--- a/test/server/fixtures/token/index.js
+++ b/test/server/fixtures/token/index.js
@@ -1,9 +1,3 @@
-
-/**
- * FIXME: need to get more decline messages: cvv, invalid fields, etc
- * This is contingent upon tokenizing with non-test cards
- */
-
 /**
  * Recurly standard magic decline number
  */

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -7,6 +7,7 @@ const jsonp = require('koa-jsonp');
 const route = require('koa-route');
 const logger = require('koa-logger');
 const bodyParser = require('koa-bodyparser');
+const methodOverride = require('koa-override');
 const koaQs = require('koa-qs');
 
 const app = new Koa();
@@ -14,6 +15,7 @@ const port = process.env.PORT || 9877;
 
 koaQs(app);
 app.use(bodyParser());
+app.use(methodOverride());
 app.use(jsonp());
 app.use(cors());
 
@@ -34,6 +36,7 @@ app.use(route.get('/tax', json));
 app.use(route.get('/token', json));
 app.use(route.post('/token', json));
 app.use(route.get('/tokens/:token_id', json));
+app.use(route.get('/tokens', json));
 app.use(route.post('/tokens', json));
 
 app.use(route.get('/apple_pay/info', json));

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -31,7 +31,7 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({ filename: 'recurly.css' })
   ],
-  devtool: 'inline-source-map',
+  devtool: 'inline-source-map'
 };
 
 // Only instrument in CI if we're set to report coverage


### PR DESCRIPTION
**Summary**

- Adds tokenization support for IBAN bank accounts to `recurly.bankAccount.token`

**Usage**

```html
<form id="iban-form">
  <input type="text" data-recurly="name_on_account" placeholder="Name on Account">
  <input type="text" data-recurly="iban" placeholder="IBAN">
</form>
```

```js
recurly.bankAccount.token(document.querySelector('#iban-form'), (err, token) => {
  if (err) {
    // handle err
  } else {
    // token.type => 'iban_bank_account'
    // token.id
  }
});
```