### PR TITLE
Specifies local and debug options for unit tests run in Browserstack

### DIFF
--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -25,6 +25,8 @@ function runner (config) {
       project,
       build: `${TRAVIS_BUILD_NUMBER || `local unit [${branchName()}]`}`,
       autoAcceptAlerts: true,
+      'browserstack.local': true,
+      'browserstack.debug': true,
       'browserstack.console': 'verbose',
       'browserstack.networkLogs': true,
       captureTimeout: 1200,


### PR DESCRIPTION
Fixes CI failures by ensuring `localIdentifier` is specified to browserstack, ensuring connection success.