### PR TITLE
Adds PayPal#destroy

### DIFF
--- a/lib/recurly/paypal/index.js
+++ b/lib/recurly/paypal/index.js
@@ -52,6 +52,15 @@ class PayPal extends Emitter {
     return this.strategy.start(...args);
   }
 
+  destroy () {
+    const { strategy } = this;
+    if (strategy) {
+      strategy.destroy();
+      delete this.strategy;
+    }
+    this.off();
+  }
+
   /**
    * Handles strategy failure scenario
    *

--- a/lib/recurly/paypal/strategy/braintree.js
+++ b/lib/recurly/paypal/strategy/braintree.js
@@ -82,7 +82,7 @@ export class BraintreeStrategy extends PayPalStrategy {
     let tokenOpts = Object.assign({}, this.config.display, { flow: 'vault' });
 
     // Tokenize with Braintree
-    this.paypal.tokenize(tokenOpts, (error, payload) => {
+    const { close } = this.paypal.tokenize(tokenOpts, (error, payload) => {
       if (error) {
         if (error.code === 'PAYPAL_POPUP_CLOSED') return this.emit('cancel');
         return this.error('paypal-braintree-tokenize-braintree-error', { cause: error });
@@ -104,6 +104,15 @@ export class BraintreeStrategy extends PayPalStrategy {
         }
       });
     });
+
+    this.close = close;
+  }
+
+  destroy () {
+    if (this.close) {
+      this.close();
+    }
+    this.off();
   }
 
   braintreeClientAvailable (module) {

--- a/lib/recurly/paypal/strategy/direct.js
+++ b/lib/recurly/paypal/strategy/direct.js
@@ -21,13 +21,20 @@ export class DirectStrategy extends PayPalStrategy {
 
   start () {
     const { payload } = this;
-    const frame = this.recurly.Frame({ path: '/paypal/start', payload });
+    const frame = this.frame = this.recurly.Frame({ path: '/paypal/start', payload });
     frame.once('done', token => this.emit('token', token));
     frame.once('close', () => this.emit('cancel'));
     frame.once('error', cause => {
       if (cause.code === 'paypal-cancel') this.emit('cancel');
       this.error('paypal-tokenize-error', { cause });
     });
+  }
+
+  destroy () {
+    if (this.frame) {
+      this.frame.destroy();
+    }
+    this.off();
   }
 }
 

--- a/test/types/paypal.ts
+++ b/test/types/paypal.ts
@@ -22,4 +22,5 @@ export default function paypal() {
   paypal.on('fake-event', () => {});
 
   paypal.start();
+  paypal.destroy();
 }

--- a/test/unit/paypal/paypal.test.js
+++ b/test/unit/paypal/paypal.test.js
@@ -12,6 +12,7 @@ apiTest(function (requestMethod) {
     beforeEach(function () {
       this.recurly = initRecurly({ cors: requestMethod === 'cors' });
       this.paypal = this.recurly.PayPal();
+      this.sandbox = sinon.createSandbox();
     });
 
     it('uses a direct PayPal strategy by default', function () {
@@ -62,5 +63,14 @@ apiTest(function (requestMethod) {
         });
       });
     });
+
+    describe('destroy', function () {
+      it('deletes the strategy and removes listeners', function () {
+        this.sandbox.spy(this.paypal, 'off');
+        this.paypal.destroy();
+        assert.equal(this.paypal.strategy, undefined);
+        assert(this.paypal.off.calledOnce);
+      })
+    })
   });
 });

--- a/test/unit/paypal/strategy/braintree.test.js
+++ b/test/unit/paypal/strategy/braintree.test.js
@@ -12,8 +12,31 @@ apiTest(function (requestMethod) {
     stubBraintree();
 
     beforeEach(function () {
+      this.sandbox = sinon.createSandbox();
       this.recurly = initRecurly({ cors: requestMethod === 'cors' });
       this.paypal = this.recurly.PayPal(validOpts);
+    });
+
+    describe('start', function () {
+      it('calls tokenize through braintree', function () {
+        this.sandbox.spy(this.paypal.strategy.paypal, 'tokenize');
+        this.paypal.start();
+        assert(this.paypal.strategy.paypal.tokenize.calledOnce);
+      });
+    })
+
+    describe('destroy', function () {
+      it('closes the window and removes listeners', function () {
+        this.sandbox.spy(this.paypal, 'off');
+        this.paypal.start();
+        // need to instantiate the spy after calling paypal.start to spy on `strategy.close`
+        this.sandbox.spy(this.paypal.strategy, 'close');
+        // need to preserve this because paypal.destroy() deletes the strategy
+        const closeRef = this.paypal.strategy.close;
+        this.paypal.destroy();
+        assert(closeRef.calledOnce);
+        assert(this.paypal.off.calledOnce);
+      });
     });
   });
 });

--- a/test/unit/paypal/strategy/direct.test.js
+++ b/test/unit/paypal/strategy/direct.test.js
@@ -57,4 +57,18 @@ describe('DirectStrategy', function () {
     this.paypal.start();
     setTimeout(() => this.recurly.Frame.getCall(0).returnValue.emit('close'), 500);
   });
+
+  describe('destroy', function () {
+    it('closes the window and removes listeners', function () {
+      this.sandbox.spy(this.paypal, 'off');
+      this.paypal.start();
+      // need to instantiate the spy after calling paypal.start to spy on `strategy.frame`
+      this.sandbox.spy(this.paypal.strategy.frame, 'destroy');
+      // need to preserve this because paypal.destroy() deletes the strategy
+      const destroyRef = this.paypal.strategy.frame.destroy;
+      this.paypal.destroy();
+      assert(destroyRef.calledOnce);
+      assert(this.paypal.off.calledOnce);
+    });
+  });
 });

--- a/test/unit/support/helpers.js
+++ b/test/unit/support/helpers.js
@@ -46,7 +46,15 @@ export function nextTick (cb) {
 
 export function stubBraintree () {
   beforeEach(() => {
-    const create = (opt, cb) => cb(null, {});
+    const create = (opt, cb) => cb(null, {
+      tokenize: (opts, cb) => {
+        cb(null, {})
+
+        return {
+          close: () => {}
+        }
+      }
+    });
     window.braintree = {
       client: {
         VERSION: BRAINTREE_CLIENT_VERSION,

--- a/types/paypal.ts
+++ b/types/paypal.ts
@@ -20,6 +20,7 @@ export type PayPalEvent = 'error' | 'token';
 export interface PayPalInstance extends Emitter<PayPalEvent> {
   start: VoidFunction;
   token: TokenHandler;
+  destroy: VoidFunction;
 }
 
 export type PayPal = (config?: PayPalConfig) => PayPalInstance;


### PR DESCRIPTION
Need to add tests for this

- Adds PayPalStrategy#destroy
- Adds '- DirectStrategy#destroy
- Adds '- BraintreeStrategy#destroy
- Will remove listeners, unwind dependencies, and destroy active dependent frames