### PR TITLE
Sends requested currency in `GET /apple_pay/info` requests

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -186,6 +186,7 @@ class ApplePay extends Emitter {
 
     this.recurly.request.get({
       route: '/apple_pay/info',
+      data: { currency: options.currency },
       done: this.applyRemoteConfig(options)
     });
   }


### PR DESCRIPTION
This will help determine more narrow transaction capabilities