### PR TITLE
Throws missing plan code error if plan is an empty string

### DIFF
--- a/lib/recurly/plan.js
+++ b/lib/recurly/plan.js
@@ -18,7 +18,7 @@ export default function plan (code, done) {
     throw new Error('Missing callback');
   }
 
-  if (typeof code === 'undefined') {
+  if (typeof code === 'undefined' || code === '') {
     return done(new Error('Missing plan code'));
   }
 


### PR DESCRIPTION
Previously, when an empty string was passed to the plan function as the code param, a network request would initiate to /js/v1/plan/?<params>, resulting in a network error.

This improves error messaging by throwing a "Missing plan code" error when the plan code is empty instead of a generic network error.