### PR TITLE
Fixes BankAccount type test

### DIFF
--- a/test/types/bank-account.ts
+++ b/test/types/bank-account.ts
@@ -13,7 +13,23 @@ export default function bankAccount() {
     }
   });
 
-  window.recurly.bankAccount.token(formEl, (err, token) => {
+  const billingInfo = {
+    routing_number: '123456780',
+    account_number: '111111111',
+    account_number_confirmation: '111111111',
+    account_type: 'checking',
+    iban: '123',
+    name_on_account: 'Pat Smith',
+    address1: '123 Main St.',
+    address2: 'Unit 1',
+    city: 'Hope',
+    state: 'WA',
+    postal_code: '98552',
+    country: 'US',
+    vat_number: 'SE0000',
+  };
+
+  window.recurly.bankAccount.token(billingInfo, (err, token) => {
     if (err) {
       err.message;
       err.code;


### PR DESCRIPTION
This fixes a gap in our testing for bankAccount.token. It looks like I originally wrote the same test twice for the first parameter as an HTMLFormElement and forgot to test for BillingInfo.