### PR TITLE
Fixes release notes version determination

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          version=$(echo ${${{ github.ref }}/v/})
+          version=$(echo '${{ github.ref }}' | sed 's/^.*v//')
           changes=$(sed -n "/^### Version $version/,/^###/p" CHANGELOG.md | sed '$d' | sed '1d')
           links=$(cat CHANGELOG.md | grep '^\[')
           echo "::set-output name=name::$version"


### PR DESCRIPTION
- the ref substitution does not properly handle the git tag ref prefix. This addresses that, and will fix the automated release notes generation.