### PR TITLE
Patches dtslint config to match DefinitelyTyped

### DIFF
--- a/.github/workflows/dt.yaml
+++ b/.github/workflows/dt.yaml
@@ -25,15 +25,25 @@ jobs:
           git config user.password ${{ secrets.DEFINITELY_TYPED_PR_GITHUB_ACCESS_TOKEN }}
           git remote set-url origin https://github.com/dbrudner/DefinitelyTyped
           git fetch --unshallow -p origin
+      - name: Add DefinitelyTyped header
+        run: |
+          version=$(cat recurly-js/package.json | jq '.version' -r | sed -ne 's/^\([0-9]*\.[0-9]*\).*/\1/p')
+          echo "// Type definitions for non-npm package recurly__recurly-js $version
+          // Project: https://github.com/recurly/recurly-js
+          // Definitions by: Dave Brudner <https://github.com/dbrudner>
+          //                 Chris Rogers <https://github.com/chrissrogers>
+          // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+          // TypeScript Version: 3.1
+          $(cat recurly-js/types/index.d.ts)" > recurly-js/types/index.d.ts
       - name: Move files
         run: |
+          rm recurly-js/test/types/tsconfig.json recurly-js/test/types/index.d.ts recurly-js/types/tsconfig.json recurly-js/types/tslint.json
           cp -R recurly-js/types/* DefinitelyTyped/types/recurly__recurly-js
           cp -R recurly-js/test/types/* DefinitelyTyped/types/recurly__recurly-js/test
-          rm DefinitelyTyped/types/recurly__recurly-js/test/tsconfig.json DefinitelyTyped/types/recurly__recurly-js/test/index.d.ts
       - id: get-version
         run: |
-          VERSION=$(cat recurly-js/package.json | jq '.version' -r )
-          echo ::set-output name=version::$VERSION
+          version=$(cat recurly-js/package.json | jq '.version' -r )
+          echo ::set-output name=version::$version
       - name: open PR
         uses: dbrudner/create-pull-request@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test-e2e-ci: build $(src) $(tests)
 	@$(wdio) wdio.ci.conf.js
 test-types: types
 	$(dts) test/types
+	@$(dts) types
 lint: build
 	@$(eslint)
 lint-fix: build

--- a/test/types/token/hosted-field.ts
+++ b/test/types/token/hosted-field.ts
@@ -1,13 +1,17 @@
 export default function hostedFieldToken() {
-  window.recurly.token(document.querySelector('form'), (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
+  const form = document.querySelector('form');
+
+  if (form) {
+    window.recurly.token(form, (err, token) => {
+      if (err) {
+        err.message;
+        err.code;
+      } else {
+        token.id;
+        token.type;
+      }
+    });
+  }
 
   // $ExpectError
   window.recurly.token(document.querySelector('div'), () => {});

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "lib": ["es6", "dom"],
-    "noImplicitAny": false,
-    "noImplicitThis": false,
-    "strictNullChecks": false,
-    "strictFunctionTypes": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
     "esModuleInterop": true,
     "types": [],
     "baseUrl": "../../types",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for non-npm package recurly__recurly-js 4.12
-// Project: https://github.com/recurly/recurly-js
-// Definitions by: Dave Brudner <https://github.com/dbrudner>
-//                 Chris Rogers <https://github.com/chrissrogers>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
-
 import { Recurly } from './lib/recurly';
 
 declare global {

--- a/types/lib/emitter.d.ts
+++ b/types/lib/emitter.d.ts
@@ -11,4 +11,4 @@ interface Emitter<Event = string> {
 
 export {
   Emitter
-}
+};

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": []
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "interface-over-type-literal": false
+  }
+}


### PR DESCRIPTION
DefinitelyTyped PR here https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45675 with checks passing triggered from this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45675/checks?check_run_id=852435520

### 1. Adds linting for /types.

Previously, we only ran tests on test/types, but DefinitelyTyped is also linting the types themselves, not just the tests, resulting in potential undiscovered linting errors emerging when opening our PR to DefinitelyTyped (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45675/checks?check_run_id=801301793)

To fix this, we're now linting our types with dtslint. We had to move types/ to DefinitelyTyped/types/recurly__recurly-js to circumvent this error https://github.com/microsoft/dtslint/blob/master/src/index.ts#L214-L227

This was also added as a CI step.

### 2. Fixes test/tslint.json to match dtslint

We had some discrepancies in our tsconfig.compilerOptions that caused typescript to behave differently. We updated test/tslint.json to match the one on DefinitelyTyped.

### 3. Fixes linting and testing errors from updated config

The errors being addressed are the same errors on DefinitelyTyped causing CI to fail.