### PR TITLE
Enhances types for BankAccount

### DIFF
--- a/test/types/bank-account.ts
+++ b/test/types/bank-account.ts
@@ -1,9 +1,7 @@
+import { TokenHandler, BacsBillingInfo, BecsBillingInfo } from 'recurly__recurly-js';
+
 export default function bankAccount() {
-  const formEl = document.querySelector('form');
-
-  if (!formEl) return;
-
-  window.recurly.bankAccount.token(formEl, (err, token) => {
+  const handleToken: TokenHandler = (err, token) => {
     if (err) {
       err.message;
       err.code;
@@ -11,7 +9,13 @@ export default function bankAccount() {
       token.id;
       token.type;
     }
-  });
+  };
+
+  const formEl = document.querySelector('form');
+
+  if (formEl) {
+    window.recurly.bankAccount.token(formEl, handleToken);
+  }
 
   const billingInfo = {
     routing_number: '123456780',
@@ -29,114 +33,75 @@ export default function bankAccount() {
     vat_number: 'SE0000',
   };
 
-  window.recurly.bankAccount.token(billingInfo, (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
+  window.recurly.bankAccount.token(billingInfo, handleToken);
+
+  const div = document.querySelector('div');
+
+  if (div) {
+    // $ExpectError
+    window.recurly.bankAccount.token(document.querySelector('div'), handleToken);
+  }
 
   // $ExpectError
-  window.recurly.bankAccount.token(document.querySelector('div'), (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
+  window.recurly.bankAccount.token('selector', handleToken);
 
-  // $ExpectError
-  window.recurly.bankAccount.token('selector', (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
-
-  const minimalBacsBillingInfo = {
+  const minimalBacsBillingInfo: BacsBillingInfo = {
     type: 'bacs',
-    account_number: "1234",
-    account_number_confirmation: "1234",
-    sort_code: "1234",
-    name_on_account: "1234"
+    account_number: '1234',
+    account_number_confirmation: '1234',
+    sort_code: '1234',
+    name_on_account: '1234'
   };
 
-  window.recurly.bankAccount.token(minimalBacsBillingInfo, (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
+  window.recurly.bankAccount.token(minimalBacsBillingInfo, handleToken);
 
-  const minimalBecsBillingInfo = {
-    type: "becs",
-    account_number: "1234",
-    account_number_confirmation: "1234",
-    branch_code: "1234",
-    name_on_account: "1234",
+  const minimalBecsBillingInfo: BecsBillingInfo = {
+    type: 'becs',
+    account_number: '1234',
+    account_number_confirmation: '1234',
+    branch_code: '1234',
+    name_on_account: '1234',
   };
 
-  window.recurly.bankAccount.token(minimalBecsBillingInfo, (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
-
-  const missingNameOnAccountBacsBillingInfo = {
-    type: 'bacs',
-    account_number: "1234",
-    account_number_confirmation: "1234",
-    sort_code: "1234",
-  };
+  window.recurly.bankAccount.token(minimalBecsBillingInfo, handleToken);
 
   // $ExpectError
-  window.recurly.bankAccount.token(missingNameOnAccountBacsBillingInfo, (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
-
-  const addressBecsBillingInfo = {
-    type: "becs",
-    name_on_account: "1234",
-    account_number: "1234",
-    account_number_confirmation: "1234",
-    sort_code: "1234",
-    address1: "asdf",
-    address2: "asdf",
-    city: "asdf",
-    state: "asdf",
-    postal_code: "asdf",
-    country: "asdf",
-    vat_number: "asdf"
+  const missingNameOnAccountBacsBillingInfo: BacsBillingInfo = {
+    type: 'bacs',
+    account_number: '1234',
+    account_number_confirmation: '1234',
+    sort_code: '1234',
   };
 
-  window.recurly.bankAccount.token(addressBecsBillingInfo, (err, token) => {
-    if (err) {
-      err.message;
-      err.code;
-    } else {
-      token.id;
-      token.type;
-    }
-  });
+  const wrongTypeOnAccountBacsBillingInfo: BacsBillingInfo = {
+    // $ExpectError
+    type: 'becs',
+    account_number: '1234',
+    account_number_confirmation: '1234',
+    sort_code: '1234',
+  };
+
+  const addressBecsBillingInfo: BecsBillingInfo = {
+    type: 'becs',
+    name_on_account: '1234',
+    account_number: '1234',
+    account_number_confirmation: '1234',
+    branch_code: '1234',
+    address1: 'asdf',
+    address2: 'asdf',
+    city: 'asdf',
+    state: 'asdf',
+    postal_code: 'asdf',
+    country: 'asdf',
+    vat_number: 'asdf'
+  };
+
+  window.recurly.bankAccount.token(addressBecsBillingInfo, handleToken);
+
+  const sepaBillingInfo = {
+    iban: 'my-iban-number',
+    name_on_account: 'name'
+  };
+
+  window.recurly.bankAccount.token(sepaBillingInfo, handleToken);
 }

--- a/test/types/index.d.ts
+++ b/test/types/index.d.ts
@@ -1,1 +1,2 @@
+// Minimum TypeScript Version: 3.1
 export * from '../../types';

--- a/types/lib/bank-account.d.ts
+++ b/types/lib/bank-account.d.ts
@@ -1,16 +1,8 @@
 import { RecurlyError } from './error';
 import { TokenHandler } from './token';
 
-export type BillingInfo = {
+export type BillingInfoCommonFields = {
   name_on_account: string;
-  routing_number?: string;
-  account_number?: string;
-  account_number_confirmation?: string;
-  account_type?: string;
-  sort_code?: string;
-  type?: string;
-  iban?: string;
-  bsb_code?: string;
   address1?: string;
   address2?: string;
   city?: string;
@@ -19,6 +11,41 @@ export type BillingInfo = {
   country?: string;
   vat_number?: string;
 };
+
+export type SepaBillingInfo = BillingInfoCommonFields & {
+  name_on_account: string;
+
+  /**
+   * The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check
+   * digits; and a number that includes the domestic bank account number, branch identifier, and potential routing
+   * information.
+   */
+  iban: string;
+};
+
+export type AccountInfo = BillingInfoCommonFields & {
+  account_number: string;
+  account_number_confirmation: string;
+};
+
+export type BacsBillingInfo = AccountInfo & {
+  type: 'bacs';
+  /**
+   * Bank identifier code for UK based banks.
+   */
+  sort_code: string;
+};
+
+export type BecsBillingInfo = AccountInfo & {
+  type: 'becs';
+  branch_code: string;
+};
+
+export type BankAccountBillingInfo = AccountInfo & {
+  routing_number: string;
+};
+
+export type BillingInfo = SepaBillingInfo | BacsBillingInfo | BecsBillingInfo | BankAccountBillingInfo;
 
 export type BankInfoOptions = {
   /**


### PR DESCRIPTION
The goal here is to update the types for BankAccount so they reflect the runtime as accurately as they can. These changes are intended to provide type checking around the shape of the object getting passed to `BankAccount.token` by breaking down `BillingInfo` into its base payment types (ACH, SEPA, BACS, BECS).