### PR TITLE
Allows react-recurly unit test step to fail when the Travis build is for a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ jobs:
       services:
         - xvfb
     - name: react-recurly
+      allow_failures:
+        if: env(TRAVIS_PULL_REQUEST) != false
       env: RECURLY_JS_SHA=$TRAVIS_COMMIT
       script:
         - mkdir -p vendor && cd vendor


### PR DESCRIPTION
- `allow_failures`