### PR TITLE
Fixes thrown error from calling recurly.configure with undefined params

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -406,7 +406,7 @@ export class Recurly extends Emitter {
  * @return {Object}
  */
 function normalizeOptions (options) {
-  const baseStyleConfig = options.style || {};
+  const baseStyleConfig = options?.style || {};
 
   delete options.style;
 


### PR DESCRIPTION
Currently, when `recurly.configure` is called with empty args, it throws an error before reaching the missing-public-key error
![image](https://user-images.githubusercontent.com/32269552/100677962-bd766880-3331-11eb-8e2a-b471c1a2a8f7.png)

This fixes the issue by fixing normalizeOptions to safely access options.style before continuing.

