### PR TITLE
remove redirectURL from WorldpayStrategy

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/worldpay.js
+++ b/lib/recurly/risk/three-d-secure/strategy/worldpay.js
@@ -29,8 +29,7 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
       path: '/risk/data_collector',
       payload: {
         bin,
-        jwt,
-        redirect_url: 'https://secure-test.worldpay.com/shopper/3ds/ddc.html'
+        jwt
       },
       container: window.document.body,
       type: Frame.TYPES.IFRAME,
@@ -81,7 +80,6 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
 
     const { actionToken, container, threeDSecure, redirectUrl } = this;
     const { recurly } = threeDSecure.risk;
-
     const payload = {
       redirect_url: redirectUrl,
       three_d_secure_action_token_id: actionToken.id

--- a/lib/recurly/risk/three-d-secure/strategy/worldpay.js
+++ b/lib/recurly/risk/three-d-secure/strategy/worldpay.js
@@ -16,7 +16,7 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
    * @param {String} options.jwt JWT
    * @return {Promise}
    */
-  static preflight ({ recurly, number, jwt }) {
+  static preflight ({ recurly, number, jwt, deviceDataCollectionUrl }) {
     const { preflightDeviceDataCollector } = recurly.config.risk.threeDSecure;
 
     if(!preflightDeviceDataCollector) {
@@ -29,7 +29,8 @@ export default class WorldpayStrategy extends ThreeDSecureStrategy {
       path: '/risk/data_collector',
       payload: {
         bin,
-        jwt
+        jwt,
+        redirect_url: deviceDataCollectionUrl
       },
       container: window.document.body,
       type: Frame.TYPES.IFRAME,

--- a/test/e2e/display.test.js
+++ b/test/e2e/display.test.js
@@ -82,7 +82,7 @@ function assertDiffThresholdMet (diff) {
   } else if (environmentIs(DEVICES.IOS)) {
     threshold = 0.25;
   } else if (environmentIs(BROWSERS.EDGE)) {
-    threshold = 0.05;
+    threshold = 0.06;
   } else if (environmentIs(BROWSERS.FIREFOX)) {
    threshold = 0.1;
   }

--- a/test/unit/risk/three-d-secure/strategy/worldpay.test.js
+++ b/test/unit/risk/three-d-secure/strategy/worldpay.test.js
@@ -37,6 +37,7 @@ describe('WorldpayStrategy', function () {
       this.sessionId = 'test-worldpay-session-id';
       this.number = '4111111111111111';
       this.jwt = 'test-preflight-jwt';
+      this.deviceDataCollectionUrl = "https://secure-test.worldpay.com/shopper/3ds/ddc.html";
       this.simulatePreflightResponse = () => {
         // Stubs expected message format from Worldpay DDC
         recurly.bus.emit('raw-message', {
@@ -49,16 +50,16 @@ describe('WorldpayStrategy', function () {
     });
 
     it('returns a promise', function (done) {
-      const { recurly, Strategy, number, jwt, simulatePreflightResponse } = this;
-      const retValue = Strategy.preflight({ recurly, number, jwt }).then(() => done());
+      const { recurly, Strategy, number, jwt, deviceDataCollectionUrl, simulatePreflightResponse } = this;
+      const retValue = Strategy.preflight({ recurly, number, jwt, deviceDataCollectionUrl }).then(() => done());
       assert(retValue instanceof Promise);
       simulatePreflightResponse();
     });
 
     it('constructs a frame to collect a session id', function (done) {
-      const { recurly, Strategy, number, jwt, simulatePreflightResponse } = this;
+      const { recurly, Strategy, number, jwt, deviceDataCollectionUrl, simulatePreflightResponse } = this;
 
-      Strategy.preflight({ recurly, number, jwt }).then(() => done());
+      Strategy.preflight({ recurly, number, jwt, deviceDataCollectionUrl }).then(() => done());
 
       assert(recurly.Frame.calledOnce);
       assert(recurly.Frame.calledWithMatch({
@@ -66,7 +67,7 @@ describe('WorldpayStrategy', function () {
         payload: {
           bin: number.substr(0,6),
           jwt,
-          redirect_url: 'https://secure-test.worldpay.com/shopper/3ds/ddc.html'
+          redirect_url: deviceDataCollectionUrl
         },
         type: Frame.TYPES.IFRAME,
         height: 0,
@@ -77,9 +78,9 @@ describe('WorldpayStrategy', function () {
     });
 
     it('resolves when a session id is received', function (done) {
-      const { recurly, Strategy, number, jwt, sessionId, simulatePreflightResponse } = this;
+      const { recurly, Strategy, number, jwt, deviceDataCollectionUrl, sessionId, simulatePreflightResponse } = this;
 
-      Strategy.preflight({ recurly, number, jwt }).then(preflightResponse => {
+      Strategy.preflight({ recurly, number, jwt, deviceDataCollectionUrl }).then(preflightResponse => {
         assert.strictEqual(preflightResponse.session_id, sessionId);
         done();
       });


### PR DESCRIPTION
Remove redirectURL from WorldpayStrategy so that we can dynamically change development vs production URLS in RA.