### PR TITLE
add gateway suggested field to braintree 3ds flow

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/braintree.js
+++ b/lib/recurly/risk/three-d-secure/strategy/braintree.js
@@ -65,6 +65,7 @@ export default class BraintreeStrategy extends ThreeDSecureStrategy {
           amount: amount,
           nonce: nonce,
           bin: bin,
+          challengeRequested: true,
           onLookupComplete: (data, next) => {
             next();
           }

--- a/test/unit/risk/three-d-secure/strategy/braintree.test.js
+++ b/test/unit/risk/three-d-secure/strategy/braintree.test.js
@@ -86,6 +86,7 @@ describe('BraintreeStrategy', function () {
           amount: 50,
           nonce: "test-braintree-nonce",
           bin: "test-braintree-bin",
+          challengeRequested: true,
           onLookupComplete: sinon.match.func
         }));
 


### PR DESCRIPTION
Include suggested parameter to override the default behavior of 3DS2 for Braintree and request the cardholder's bank to issue an authentication challenge.