### PR TITLE
Select PayPal gateway

### DIFF
--- a/lib/recurly/paypal/strategy/direct.js
+++ b/lib/recurly/paypal/strategy/direct.js
@@ -16,6 +16,7 @@ export class DirectStrategy extends PayPalStrategy {
     if (this.config.display.amount) payload.amount = this.config.display.amount;
     if (this.config.display.logoImageUrl) payload.logoImageUrl = this.config.display.logoImageUrl;
     if (this.config.display.headerImageUrl) payload.headerImageUrl = this.config.display.headerImageUrl;
+    if (this.config.gatewayCode) payload.gatewayCode = this.config.gatewayCode;
     return payload;
   }
 

--- a/lib/recurly/paypal/strategy/index.js
+++ b/lib/recurly/paypal/strategy/index.js
@@ -51,6 +51,7 @@ export class PayPalStrategy extends Emitter {
   configure (options) {
     if (!(options.recurly instanceof Recurly)) throw this.error('paypal-factory-only');
     this.recurly = options.recurly;
+    if (options.gatewayCode) this.config.gatewayCode = options.gatewayCode;
 
     this.config.display = {};
 

--- a/test/unit/paypal/strategy/direct.test.js
+++ b/test/unit/paypal/strategy/direct.test.js
@@ -51,6 +51,27 @@ describe('DirectStrategy', function () {
     });
   });
 
+  context('when given a gateway code', function () {
+    const gatewayCode = 'qn1234a5bcde';
+    const gatewayOpts = { display: { displayName }, gatewayCode };
+
+    beforeEach(function () {
+      this.paypal = this.recurly.PayPal(gatewayOpts);
+    });
+
+    it('Passes the description and gateway code to the API start endpoint', function () {
+      this.paypal.start();
+      assert(this.recurly.Frame.calledOnce);
+      assert(this.recurly.Frame.calledWith(sinon.match({
+        path: '/paypal/start',
+        payload: sinon.match({
+          description: displayName,
+          gatewayCode
+        })
+      })));
+    });
+  });
+
   it('emits a cancel event when the window closes', function (done) {
     this.timeout(2500); // timeout with error if paypal doesn't emit cancel event
     this.paypal.on('cancel', () => done());


### PR DESCRIPTION
Include `gatewayCode` as a parameter to allow for specific PayPal gateway routing when multiple PayPal gateways enabled.