### PR TITLE
Sequential Preflight Calls

### DIFF
--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -76,19 +76,17 @@ export class ThreeDSecure extends RiskConcern {
    * @return {Promise}
    */
   static preflight ({ recurly, number, month, year, preflights }) {
-    const finished_preflights = [];
     return preflights.reduce((preflight, result) => {
-      return preflight.then(() => {
+      return preflight.then((finishedPreflights) => {
         const { type } = result.gateway;
         const { gateway_code } = result.params;
         const strategy = ThreeDSecure.getStrategyForGatewayType(type);
         return strategy.preflight({ recurly, number, month, year, ...result.params })
-          .then(results =>{
-            finished_preflights.push({ processor: type, gateway_code,  results });
-            return finished_preflights;
+          .then(results => {
+            return finishedPreflights.concat([{ processor: type, gateway_code, results }]);
           });
       });
-    }, Promise.resolve());
+    }, Promise.resolve([]));
   }
 
   constructor ({ risk, actionTokenId }) {

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -88,8 +88,8 @@ export class ThreeDSecure extends RiskConcern {
             return finished_preflights;
           });
       });
-    }, Promise.resolve())
-}
+    }, Promise.resolve());
+  }
 
   constructor ({ risk, actionTokenId }) {
     super({ risk });

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -76,7 +76,7 @@ export class ThreeDSecure extends RiskConcern {
    * @return {Promise}
    */
   static preflight ({ recurly, number, month, year, preflights }) {
-    const finished_preflights = []
+    const finished_preflights = [];
     return preflights.reduce((preflight, result) => {
       return preflight.then(() => {
         const { type } = result.gateway;
@@ -84,8 +84,10 @@ export class ThreeDSecure extends RiskConcern {
         const strategy = ThreeDSecure.getStrategyForGatewayType(type);
         return strategy.preflight({ recurly, number, month, year, ...result.params })
           .then(results =>{
-            finished_preflights.push({processor: type, gateway_code,  results })
-           return finished_preflights})})
+            finished_preflights.push({ processor: type, gateway_code,  results });
+            return finished_preflights;
+          });
+      });
     }, Promise.resolve())
 }
 

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -76,13 +76,18 @@ export class ThreeDSecure extends RiskConcern {
    * @return {Promise}
    */
   static preflight ({ recurly, number, month, year, preflights }) {
-    return Promise.all(preflights.map(preflight => {
-      const { type } = preflight.gateway;
-      const strategy = ThreeDSecure.getStrategyForGatewayType(type);
-      return strategy.preflight({ recurly, number, month, year, ...preflight.params })
-        .then(results => ({ processor: type, results }));
-    }));
-  }
+    const finished_preflights = []
+    return preflights.reduce((preflight, result) => {
+      return preflight.then(() => {
+        const { type } = result.gateway;
+        const { gateway_code } = result.params;
+        const strategy = ThreeDSecure.getStrategyForGatewayType(type);
+        return strategy.preflight({ recurly, number, month, year, ...result.params })
+          .then(results =>{
+            finished_preflights.push({processor: type, gateway_code,  results })
+           return finished_preflights})})
+    }, Promise.resolve())
+}
 
   constructor ({ risk, actionTokenId }) {
     super({ risk });


### PR DESCRIPTION
This PR changes our processing of the preflights to run authentication calls and device data collection calls in Promises that resolve sequentially instead of all at once in a Promise.all as before.

This is because the event listeners instantiated in risk strategies during this process were previously all receiving the same event since the events do necessarily have unique identifiers. 