### PR TITLE
add auto-tabbing to combined card field

### DIFF
--- a/lib/recurly/element/element.js
+++ b/lib/recurly/element/element.js
@@ -66,7 +66,7 @@ export default class Element extends Emitter {
     this.on(this.messageName('tab:previous'), () => this.onTab('previous'));
     this.on(this.messageName('tab:next'), () => this.onTab('next'));
     this.on(this.messageName('submit'), () => this.onSubmit());
-    this.on(this.messageName('autoTab'), () => this.emit('autoTab'));
+    this.on(this.messageName('autoTab'), () => this.onAutoTab());
     this.on('destroy', (...args) => this.destroy(...args));
     debug('create', this.id);
   }
@@ -395,6 +395,11 @@ export default class Element extends Emitter {
   onSubmit () {
     debug('submit', this.id);
     this.emit('submit', this);
+  }
+
+  onAutoTab () {
+    debug('autoTab', this.id);
+    this.emit('autoTab', this);
   }
 }
 

--- a/lib/recurly/element/element.js
+++ b/lib/recurly/element/element.js
@@ -66,6 +66,7 @@ export default class Element extends Emitter {
     this.on(this.messageName('tab:previous'), () => this.onTab('previous'));
     this.on(this.messageName('tab:next'), () => this.onTab('next'));
     this.on(this.messageName('submit'), () => this.onSubmit());
+    this.on(this.messageName('autoTab'), () => this.emit('autoTab'));
     this.on('destroy', (...args) => this.destroy(...args));
     debug('create', this.id);
   }

--- a/lib/recurly/element/element.js
+++ b/lib/recurly/element/element.js
@@ -27,7 +27,8 @@ export default class Element extends Emitter {
     'displayIcon',
     'inputType',
     'style',
-    'tabIndex'
+    'tabIndex',
+    'behavior'
   ];
 
   static supportsTokenization = false;

--- a/test/unit/element.test.js
+++ b/test/unit/element.test.js
@@ -725,6 +725,14 @@ describe('Element', function () {
         sendMessage('submit');
       });
     });
+
+    describe('onAutoTab', function () {
+      it(`emits 'autoTab' when the 'autoTab' bus message is sent`, function (done) {
+        const { element, sendMessage } = this;
+        element.on('autoTab', () => done());
+        sendMessage('autoTab');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Add "behavior" as an option on element to allow the following configuration:

```
elements.CardElement({
inputType: ‘text’
  style: {
    // this does not impact autotab behavior
  },
  behavior: {
    autoTabOnComplete: true,
    expiryYear: {
      maxLength: 2
    }
  }
});
```

This will also emit an autotab event the merchant can listen to.