### PR TITLE
emit ready event

### DIFF
--- a/lib/recurly/element/element.js
+++ b/lib/recurly/element/element.js
@@ -248,7 +248,10 @@ export default class Element extends Emitter {
 
     parent.appendChild(container);
     bus.add(this.window);
-    this.once(this.messageName('ready'), () => this.emit('attach', this));
+    this.once(this.messageName('ready'), () => {
+      this.emit('ready', this.state);
+      this.emit('attach', this);
+    });
 
     return this;
   }


### PR DESCRIPTION
We are not currently emitting the 'ready' event for the client to listen to.

Since we want to remove any event listener on ready as soon as it is heard and the callback is used, this appears to be the best place to put it.

The reason we want the event listener to be removed is because the following code [here](https://github.com/recurly/recurly-js/blob/1f4281250cce5c8ddf5218d46f64899ffcc2cc4b/lib/recurly/elements.js#L147) and [here](https://github.com/recurly/recurly-js/blob/1f4281250cce5c8ddf5218d46f64899ffcc2cc4b/lib/recurly/element/element.js#L160) depend on there being no 'ready' listeners on our elements in order to call 'elements:ready!'.

This PR will emit a 'ready' event from an element instance when it hears 'element:ready', so the merchant and our [react library](https://github.com/recurly/react-recurly/blob/c2b81f6e63887b54a66178622711e3891a191cbe/lib/element/element.js#L99) can listen for it.

Testing: all current tests pass.

Note: This looked to be the best place to put the logic. Please double check there is not a better place for this.

