### PR TITLE
fix(recurly): remove conditional fraud instantiation

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -353,7 +353,7 @@ export class Recurly extends Emitter {
       return;
     }
 
-    if (!this.fraud) this.fraud = new Fraud(this);
+    this.fraud = new Fraud(this);
     this.fraud.on('error', (...args) => {
       this.emit('error', ...args);
     });


### PR DESCRIPTION
The conditional check before instantiation of the `fraud` attribute makes the calls to the `.configure()` idempotent after the first one. For instance, if some user visits the payment form, the first visit will have the `fraud_session_id` and other fields injected successfully. But if the user decides to take a tour and return to the payment form, the second `.configure()` will have no effect and no fraud attributes will be available.

Here we have two forms as an example. The second one, calls the `.configure()` after a few seconds which has no effect on creating the fraud attributes.

<img width="977" alt="unfixed" src="https://user-images.githubusercontent.com/110666094/197747830-16dbbae5-3b69-4177-b19b-b28c111e4e53.png">


With the fix in this PR, the fraud object instantiates with every `.configure()` call and the attributes are available in the second form.

<img width="1025" alt="fixed" src="https://user-images.githubusercontent.com/110666094/197748171-a78517e6-4de8-4592-a0b1-7d624868fc04.png">

Currently, we put `delete window.recurly.fraud` before the call to `.configure()` in our code to mitigate the problem but we thought it was better to create this PR.