### PR TITLE
[EE-2768] refactor apple-pay-braintree.js

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.braintree.js
+++ b/lib/recurly/apple-pay/apple-pay.braintree.js
@@ -4,7 +4,12 @@ import { ApplePay } from './apple-pay';
 
 const debug = require('debug')('recurly:apple-pay:braintree');
 
-const promisify = Promise.denodeify;
+const promisifyLoadScript = (src) => { return new Promise((resolve, reject) => {loadScript(src, (err, script) =>
+  {if (err) reject(err);
+    else resolve(script);}
+);
+});
+}
 
 const CLIENT_VERSION = '3.76.0';
 const LIBS = {


### PR DESCRIPTION
Refactor apple-pay-braintree.js to replace Promise.denodeify with similar solution that doesn't violate some merchant's CSP.

Merchant had security concerns with Promise.denodeify and suggested this change as a solution.