### PR TITLE
Update Minimum Apple Pay Version to v4

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -8,7 +8,7 @@ import { FIELDS } from '../token';
 
 const debug = require('debug')('recurly:apple-pay');
 
-const APPLE_PAY_API_VERSION = 2;
+const APPLE_PAY_API_VERSION = 3;
 const APPLE_PAY_ADDRESS_MAP = {
   first_name: 'givenName',
   last_name: 'familyName',
@@ -54,7 +54,7 @@ export class ApplePay extends Emitter {
     this.once('ready', () => this._ready = true);
 
     // Detect whether Apple Pay is available
-    if (!window.ApplePaySession) {
+    if (!(window.ApplePaySession && window.ApplePaySession.supportsVersion(APPLE_PAY_API_VERSION))) {
       this.initError = this.error('apple-pay-not-supported');
     } else if (!window.ApplePaySession.canMakePayments()) {
       this.initError = this.error('apple-pay-not-available');
@@ -76,15 +76,21 @@ export class ApplePay extends Emitter {
 
     this.addAuthorizationLineItem();
 
-    let session = new window.ApplePaySession(APPLE_PAY_API_VERSION, {
+    let sessionOptions = {
       countryCode: this.config.country,
       currencyCode: this.config.currency,
       supportedNetworks: this.config.supportedNetworks,
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
       requiredShippingContactFields: this.config.requiredShippingContactFields,
-      total: this.totalLineItem
-    });
+      total: this.totalLineItem,
+    };
+
+    if (this.config.supportedCountries) {
+      sessionOptions.supportedCountries = this.config.supportedCountries;
+    }
+
+    let session = new window.ApplePaySession(APPLE_PAY_API_VERSION, sessionOptions);
 
     session.onvalidatemerchant = this.onValidateMerchant.bind(this);
     session.onshippingcontactselected = this.onShippingContactSelected.bind(this);
@@ -294,7 +300,11 @@ export class ApplePay extends Emitter {
    */
   onPaymentMethodSelected (event) {
     debug('Payment method selected', event);
-    this.session.completePaymentMethodSelection(this.finalTotalLineItem, this.lineItems);
+
+    this.session.completePaymentMethodSelection({
+      newTotal: this.finalTotalLineItem,
+      newLineItems: this.lineItems,
+    });
   }
 
   /**
@@ -304,12 +314,15 @@ export class ApplePay extends Emitter {
    * @private
    */
   onShippingContactSelected (event) {
-    const status = this.session.STATUS_SUCCESS;
     const newShippingMethods = [];
 
     this.emit('shippingContactSelected', event);
 
-    this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
+    this.session.completeShippingContactSelection({
+      newTotal: this.finalTotalLineItem,
+      newLineItems: this.lineItems,
+      newShippingMethods,
+    });
   }
 
   /**
@@ -319,11 +332,12 @@ export class ApplePay extends Emitter {
    * @private
    */
   onShippingMethodSelected (event) {
-    const status = this.session.STATUS_SUCCESS;
-
     this.emit('shippingMethodSelected', event);
 
-    this.session.completeShippingMethodSelection(status, this.finalTotalLineItem, this.lineItems);
+    this.session.completeShippingMethodSelection({
+      newTotal: this.finalTotalLineItem,
+      newLineItems: this.lineItems,
+    });
   }
 
   /**
@@ -356,13 +370,13 @@ export class ApplePay extends Emitter {
       data,
       done: (err, token) => {
         if (err) {
-          this.session.completePayment(this.session.STATUS_FAILURE);
+          this.session.completePayment({ status: this.session.STATUS_FAILURE });
           return this.error('apple-pay-payment-failure', err);
         }
 
         debug('Token received', token);
 
-        this.session.completePayment(this.session.STATUS_SUCCESS);
+        this.session.completePayment({ status: this.session.STATUS_SUCCESS });
         this.emit('authorized', event);
         this.emit('token', token);
       }

--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -8,7 +8,7 @@ import { FIELDS } from '../token';
 
 const debug = require('debug')('recurly:apple-pay');
 
-const APPLE_PAY_API_VERSION = 3;
+const APPLE_PAY_API_VERSION = 4;
 const APPLE_PAY_ADDRESS_MAP = {
   first_name: 'givenName',
   last_name: 'familyName',
@@ -21,7 +21,6 @@ const APPLE_PAY_ADDRESS_MAP = {
 };
 
 const I18N = {
-  authorizationLineItemLabel: 'Card Authorization (Temporary)',
   subtotalLineItemLabel: 'Subtotal',
   discountLineItemLabel: 'Discount',
   taxLineItemLabel: 'Tax',
@@ -74,8 +73,6 @@ export class ApplePay extends Emitter {
 
     debug('Creating new Apple Pay session');
 
-    this.addAuthorizationLineItem();
-
     let sessionOptions = {
       countryCode: this.config.country,
       currencyCode: this.config.currency,
@@ -125,16 +122,6 @@ export class ApplePay extends Emitter {
    */
   get finalTotalLineItem () {
     return Object.assign({}, this.totalLineItem, { type: 'final' });
-  }
-
-  /**
-   * Used when the total price is zero, to circumvent Apple Pay
-   * zero amount authorization limitation
-   * @return {Object} card authorization line item, $1.00
-   * @private
-   */
-  get authorizationLineItem () {
-    return lineItem(this.config.i18n.authorizationLineItemLabel, 1.00);
   }
 
   /**
@@ -224,18 +211,6 @@ export class ApplePay extends Emitter {
     if (this.initError) return this.error('apple-pay-init-error', { err: this.initError });
     delete this._session;
     this.session.begin();
-  }
-
-  /**
-   * Conditionally adds an authorization line item in order to circumvent Apple Pay
-   * zero-amount authorization limitation
-   *
-   * @private
-   */
-  addAuthorizationLineItem () {
-    if (parseFloat(this.config.total) > 0) return;
-    this.config.lineItems.push(this.authorizationLineItem);
-    this.config.total = this.authorizationLineItem.amount;
   }
 
   /**

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -276,7 +276,6 @@ function applePayTest (integrationType, requestMethod) {
           describe('when the line item labels are customized', () => {
             beforeEach(function () {
               this.exampleI18n = {
-                authorizationLineItemLabel: 'Custom card authorization label',
                 subtotalLineItemLabel: 'Custom subtotal label',
                 discountLineItemLabel: 'Custom discount label',
                 taxLineItemLabel: 'Custom tax label',
@@ -295,21 +294,6 @@ function applePayTest (integrationType, requestMethod) {
                 assert.equal(giftCard.label, this.exampleI18n.giftCardLineItemLabel);
                 done();
               });
-            });
-          });
-
-          describe('when the total price is zero', () => {
-            beforeEach(function (done) {
-              this.pricing.coupon('coop-fixed-all-500').done(() => done());
-            });
-
-            it('adds an authorization line item', function () {
-              assert.strictEqual(this.applePay.totalLineItem.amount, '0.00');
-              this.applePay.begin();
-              const authorization = this.applePay.lineItems[2];
-              assert.strictEqual(authorization.label, this.applePay.config.i18n.authorizationLineItemLabel);
-              assert.strictEqual(authorization.amount, '1.00');
-              assert.strictEqual(this.applePay.totalLineItem.amount, '1.00');
             });
           });
 
@@ -842,49 +826,6 @@ function applePayTest (integrationType, requestMethod) {
             this.applePay.session.oncancel('event');
           });
         }
-      });
-    });
-
-    describe('Authorization line item', () => {
-      it('has a customizable label', function () {
-        const example = 'Test auth label';
-        const applePay = this.recurly.ApplePay(Object.assign({}, validOpts, {
-          i18n: { authorizationLineItemLabel: example }
-        }));
-        applePay.authorizationLineItem.label === example;
-      });
-
-      describe('when the total price is greater than zero', function () {
-        beforeEach(function (done) {
-          this.applePay = this.recurly.ApplePay(validOpts);
-          this.applePay.ready(() => {
-            this.applePay.begin();
-            done();
-          });
-        });
-
-        it('is not present', function () {
-          assert.equal(this.applePay.config.total, 3.49);
-          assert.equal(this.applePay.lineItems.length, 0);
-        });
-      });
-
-      describe('when the total price is zero', function () {
-        beforeEach(function (done) {
-          this.applePay = this.recurly.ApplePay(Object.assign({}, validOpts, {
-            total: 0
-          }));
-          this.applePay.ready(() => {
-            this.applePay.begin();
-            done();
-          });
-        });
-
-        it('is present', function () {
-          assert.equal(this.applePay.config.total, 1);
-          assert.equal(this.applePay.lineItems.length, 1);
-          assert.deepEqual(this.applePay.lineItems[0], this.applePay.authorizationLineItem);
-        });
       });
     });
   });


### PR DESCRIPTION
Requires the device to not support v4 (Mojave)

Highlights include:
- Adds ApplePay merchant configuration property [`supportedCountries`](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/2928612-supportedcountries)
- Supports $0 totals (common use case is free trials)

