### PR TITLE
Handle stripe js error when attaching the stripe element

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/stripe.js
+++ b/lib/recurly/risk/three-d-secure/strategy/stripe.js
@@ -44,11 +44,11 @@ export default class StripeStrategy extends ThreeDSecureStrategy {
 
       handleAction(this.stripeClientSecret).then(result => {
         if (result.error) {
-          return this.threeDSecure.error('3ds-auth-error', { cause: result.error });
+          throw result.error;
         }
         const { id } = result.paymentIntent || result.setupIntent;
         this.emit('done', { id });
-      });
+      }).catch(err => this.threeDSecure.error('3ds-auth-error', { cause: err }));
     });
   }
 


### PR DESCRIPTION
## Description

When attaching the stripe js elements, it may throw depending on the payment intent status.
This PR properly handles the errors to avoid waiting indefinitely for the challenge that will not appear and fail the transaction.