### PR TITLE
Multi form fraud detection

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -353,10 +353,14 @@ export class Recurly extends Emitter {
       return;
     }
 
-    if (!this.fraud) this.fraud = new Fraud(this);
-    this.fraud.on('error', (...args) => {
-      this.emit('error', ...args);
-    });
+    if (this.fraud) {
+      this.ready(this.fraud.activateProfiles);
+    } else {
+      this.fraud = new Fraud(this);
+      this.fraud.on('error', (...args) => {
+        this.emit('error', ...args);
+      });
+    }
 
     if (!this.bus) {
       this.bus = new Bus({ api: this.config.api, role: 'recurly' });

--- a/lib/recurly/fraud.js
+++ b/lib/recurly/fraud.js
@@ -69,13 +69,11 @@ export class Fraud extends Emitter {
     if (this.dataCollectorInitiated) return;
     this.dataCollectorInitiated = true;
 
-    // NOTE: this must only happen once per page load
     this.recurly.request.get({
       route: '/risk/info',
       done: (error, response) => {
         debug('risk info', error, response);
 
-        // per-page thing
         if (error) {
           return this.emit(
             'error',
@@ -83,7 +81,6 @@ export class Fraud extends Emitter {
           );
         }
 
-        // per-page thing, should only be loaded once.
         const { profiles } = response;
         this.profiles = profiles;
         this.activateProfiles();
@@ -91,7 +88,6 @@ export class Fraud extends Emitter {
     });
   }
 
-  // FIXME: need to make sure this is safe to do for every form
   activateProfiles () {
     if (!this.profiles) return;
 
@@ -105,7 +101,6 @@ export class Fraud extends Emitter {
           'type': 'hidden',
         });
 
-        // FIXME: is this once-per-page, or can we do it on every form render?
         const initialize = () => {
           if (!window.ka) {
             return this.emit(

--- a/lib/recurly/fraud.js
+++ b/lib/recurly/fraud.js
@@ -14,6 +14,8 @@ export class Fraud extends Emitter {
     if (this.shouldCollectData) {
       recurly.ready(this.attachDataCollector.bind(this));
     }
+    // make sure activateProfiles can be passed as a callback
+    this.activateProfiles = this.activateProfiles.bind(this);
   }
 
   get shouldCollectData () {
@@ -67,60 +69,79 @@ export class Fraud extends Emitter {
     if (this.dataCollectorInitiated) return;
     this.dataCollectorInitiated = true;
 
+    // NOTE: this must only happen once per page load
     this.recurly.request.get({
       route: '/risk/info',
       done: (error, response) => {
         debug('risk info', error, response);
 
+        // per-page thing
         if (error) {
-          return this.emit('error', errors('fraud-data-collector-request-failed', { error }));
+          return this.emit(
+            'error',
+            errors('fraud-data-collector-request-failed', { error })
+          );
         }
 
+        // per-page thing, should only be loaded once.
         const { profiles } = response;
+        this.profiles = profiles;
+        this.activateProfiles();
+      },
+    });
+  }
 
-        profiles.forEach(profile => {
-          const { processor, params } = profile;
-          if (processor === 'kount') {
-            const configuredForm = this.recurly.config.fraud.kount.form;
-            const scriptElement = document.createElement('script');
-            const initializerElement = document.createElement('div');
-            const sessionIdInputElement = dom.createHiddenInput({
-              'data-recurly': 'fraud_session_id',
-              'value': params.session_id,
-              'type': 'hidden'
-            });
-            const initialize = () => {
-              if (!window.ka) {
-                return this.emit('error', errors('fraud-data-collector-request-failed', {
-                  error: 'Kount SDK failed to load.'
-                }));
-              }
-              // eslint-disable-next-line no-undef
-              const client = new ka.ClientSDK();
-              client.autoLoadEvents();
-            };
+  // FIXME: need to make sure this is safe to do for every form
+  activateProfiles () {
+    if (!this.profiles) return;
 
-            scriptElement.setAttribute('src', params.script_url);
-            scriptElement.onload = initialize;
-
-            initializerElement.className = 'kaxsdc';
-            initializerElement.setAttribute('data-event', 'load');
-
-            const form = dom.element(configuredForm) || this.getHostedFieldParentForm();
-            if (form) {
-              const nodes = [
-                sessionIdInputElement,
-                scriptElement,
-                initializerElement
-              ];
-
-              nodes.forEach(node => form.appendChild(node));
-              this.attachedNodes = nodes;
-            }
-
-            this.emit('ready');
-          }
+    this.profiles.forEach((profile) => {
+      const { processor, params } = profile;
+      if (processor === 'kount') {
+        const configuredForm = this.recurly.config.fraud.kount.form;
+        const sessionIdInputElement = dom.createHiddenInput({
+          'data-recurly': 'fraud_session_id',
+          value: params.session_id,
+          'type': 'hidden',
         });
+
+        // FIXME: is this once-per-page, or can we do it on every form render?
+        const initialize = () => {
+          if (!window.ka) {
+            return this.emit(
+              'error',
+              errors('fraud-data-collector-request-failed', {
+                error: 'Kount SDK failed to load.',
+              })
+            );
+          }
+          // eslint-disable-next-line no-undef
+          const client = new ka.ClientSDK();
+          client.autoLoadEvents();
+        };
+
+        const scriptElement = document.createElement('script');
+        scriptElement.setAttribute('src', params.script_url);
+        scriptElement.onload = initialize;
+
+        const initializerElement = document.createElement('div');
+        initializerElement.className = 'kaxsdc';
+        initializerElement.setAttribute('data-event', 'load');
+
+        const form =
+          dom.element(configuredForm) || this.getHostedFieldParentForm();
+        if (form) {
+          const nodes = [
+            sessionIdInputElement,
+            scriptElement,
+            initializerElement,
+          ];
+
+          nodes.forEach((node) => form.appendChild(node));
+          this.attachedNodes = nodes;
+        }
+
+        this.emit('ready');
       }
     });
   }
@@ -135,17 +156,24 @@ export class Fraud extends Emitter {
   getHostedFieldParentForm () {
     if (this._form) return this._form;
     const fields = this.recurly.config.fields;
-    const selectors = Object.keys(fields).map(name => fields[name].selector).filter(Boolean);
+    const selectors = Object.keys(fields)
+      .map((name) => fields[name].selector)
+      .filter(Boolean);
     let form;
-    find(selectors, selector => {
-      const node = dom.findNodeInParents(window.document.querySelector(selector), 'form');
+    find(selectors, (selector) => {
+      const node = dom.findNodeInParents(
+        window.document.querySelector(selector),
+        'form'
+      );
       if (dom.element(node)) form = node;
     });
 
     if (form) {
-      return this._form = form;
+      return (this._form = form);
     } else {
-      const missingFormError = errors('fraud-data-collector-missing-form', { selectors });
+      const missingFormError = errors('fraud-data-collector-missing-form', {
+        selectors,
+      });
       this.emit('error', missingFormError);
     }
   }
@@ -154,7 +182,7 @@ export class Fraud extends Emitter {
    * Removes any attached data collectors
    */
   destroy () {
-    this.attachedNodes.forEach(node => {
+    this.attachedNodes.forEach((node) => {
       if (!node.parentElement) return;
       node.parentElement.removeChild(node);
     });

--- a/test/unit/support/fixtures.js
+++ b/test/unit/support/fixtures.js
@@ -182,9 +182,14 @@ const iframe = opts => `
   ></iframe>
 `;
 
-const threeDSecure = () => `<div id="three-d-secure-container"></div>`;
+const threeDSecure = () => '<div id="three-d-secure-container"></div>';
 
-const emptyForm = () => `<form id="test-form"></form>`;
+const emptyForm = () => '<form id="test-form"></form>';
+
+const multipleEmptyForms = () => `
+  <form id="test-form-1"></form>
+  <form id="test-form-2"></form>
+`;
 
 const selectLists = (name) => `<select id="${name}" name="${name}"></select>`;
 
@@ -207,6 +212,7 @@ const FIXTURES = {
   threeDSecure,
   empty,
   emptyForm,
+  multipleEmptyForms,
   selectLists,
   selectListsFull,
 };
@@ -243,5 +249,6 @@ export function clearFixture () {
  * @return {Mixed} value of property on object or default if none found
  */
 function fetch (object, prop, def = '') {
+  // eslint-disable-next-line no-prototype-builtins
   return object.hasOwnProperty(prop) ? object[prop] : def;
 }


### PR DESCRIPTION
This PR will allow for multiform fraud detection. It will attach data-recurly=“fraud_session_id” to multiple forms. In addition it will allow for our RiskDataCollector component to work with Kount configured. Without this change when using our react component we would not see a session id populated to the form to be submitted on tokenization. In a similar fashion, without this change, when using multiple forms/multiple calls to recurly.configure with our rjs library we would not see the fraud session id attached to additional forms added to the page after an initial call to recurly.configure.

Testing:
Create a page utilizing the recurly-js library with 2 forms. 
Use the following recurly-js script and stylesheet: 
```
<script src="https://js.qa2.recurlyqa.com/v4/recurly.js"></script>
<link href="https://js.qa2.recurlyqa.com/v4/recurly.css" rel="stylesheet" type="text/css">
```
Set up your javascript to call recurly.configure twice to configure with Kount - one time for each form.
Inspect BOTH forms to check that a hidden input is attached with data-recurly=“fraud_session_id” and a populated session id.

Notice that a fraud session id is not populated on a second form using what is currently in production: 
```
<script src="https://js.recurly.com/v4/recurly.js"></script>
<link href="https://js.recurly.com/v4/recurly.css" rel="stylesheet" type="text/css”>
```

Additionally run the accompanying test locally with this branch pulled to see that it passes on this branch and not on what is currently in staging.

