### PR TITLE
[feat][apple-pay] send hostname to server and specify applicationData

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -83,6 +83,10 @@ export class ApplePay extends Emitter {
       total: this.totalLineItem,
     };
 
+    if (this.config.applicationData) {
+      sessionOptions.applicationData = this.config.applicationData;
+    }
+
     if (this.config.supportedCountries) {
       sessionOptions.supportedCountries = this.config.supportedCountries;
     }
@@ -174,7 +178,11 @@ export class ApplePay extends Emitter {
 
     this.recurly.request.get({
       route: '/apple_pay/info',
-      data: { currency: options.currency },
+      data: {
+        currency: options.currency,
+        country: options.country,
+        host: window.location.hostname,
+      },
       done: this.applyRemoteConfig(options)
     });
   }
@@ -193,6 +201,8 @@ export class ApplePay extends Emitter {
 
       if ('currencies' in info && ~info.currencies.indexOf(options.currency)) this.config.currency = options.currency;
       else return this.initError = this.error('apple-pay-config-invalid', { opt: 'currency', set: info.currencies });
+
+      if ('subdomain' in info) this.config.applicationData = btoa(info.subdomain);
 
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
@@ -259,7 +269,7 @@ export class ApplePay extends Emitter {
 
     this.recurly.request.post({
       route: '/apple_pay/start',
-      data: { validationURL },
+      data: { host: window.location.hostname, validationURL },
       done: (err, merchantSession) => {
         if (err) return this.error(err);
         this.session.completeMerchantValidation(merchantSession);

--- a/test/server/fixtures/apple_pay/info.json
+++ b/test/server/fixtures/apple_pay/info.json
@@ -1,4 +1,5 @@
 {
+  "subdomain": "test",
   "countries": ["US", "CA"],
   "currencies": ["USD", "CAD"],
   "merchantCapabilities": ["supportsCredit", "supports3DS", "supportsDebit"],

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -339,6 +339,14 @@ function applePayTest (integrationType, requestMethod) {
           this.applePay = this.recurly.ApplePay(validOpts);
         });
 
+        it('assigns the applicationData', function (done) {
+          this.applePay.ready(() => {
+            assert.equal(this.applePay.config.applicationData,
+              btoa('test'));
+            done();
+          });
+        });
+
         it('assigns merchantCapabilities', function (done) {
           this.applePay.ready(() => {
             assert.deepEqual(this.applePay.config.merchantCapabilities, infoFixture.merchantCapabilities);


### PR DESCRIPTION
Upgrades the native ApplePay integration to:
- Utilize the merchant Recurly subdomain as the `applicationData` if present
- Submit the customer browser hostname when retrieving the merchant config and starting the AP session.

Ensure that both the native and Braintree AP integrations continue to function.