### PR TITLE
[feat][google-pay] send raw payment data to server

### DIFF
--- a/lib/recurly/google-pay/google-pay.js
+++ b/lib/recurly/google-pay/google-pay.js
@@ -43,7 +43,7 @@ const createRecurlyToken = ({ recurly, $form, paymentData, gatewayCodeSelected }
     gateway_code: gatewayCodeSelected,
     ...userInputs,
     ...(!userInputsOverrideBillingAddress && userBillingAddress),
-    google_pay_token: paymentData?.paymentMethodData?.tokenizationData?.token,
+    paymentData,
   };
 
   return recurly.request.post({ route: '/google_pay/token', data });

--- a/test/unit/google-pay/google-pay.test.js
+++ b/test/unit/google-pay/google-pay.test.js
@@ -458,7 +458,31 @@ apiTest(requestMethod => describe('Google Pay', function () {
                     postal_code: '94043',
                     address1: '1600 Amphitheatre Parkway',
                     address2: '',
-                    google_pay_token: '{"id": "tok_123"}',
+                    paymentData: {
+                      paymentMethodData: {
+                        description: 'Visa •••• 1111',
+                        tokenizationData: {
+                          type: 'PAYMENT_GATEWAY',
+                          token: '{"id": "tok_123"}',
+                        },
+                        type: 'CARD',
+                        info: {
+                          cardNetwork: 'VISA',
+                          cardDetails: '1111',
+                          billingAddress: {
+                            address3: '',
+                            sortingCode: '',
+                            address2: '',
+                            countryCode: 'US',
+                            address1: '1600 Amphitheatre Parkway',
+                            postalCode: '94043',
+                            name: 'John Smith',
+                            locality: 'Mountain View',
+                            administrativeArea: 'CA',
+                          },
+                        },
+                      },
+                    },
                     gateway_code: 'gateway_123',
                   }
                 });
@@ -496,7 +520,31 @@ apiTest(requestMethod => describe('Google Pay', function () {
                       postal_code: '123',
                       address1: '',
                       address2: '',
-                      google_pay_token: '{"id": "tok_123"}',
+                      paymentData: {
+                        paymentMethodData: {
+                          description: 'Visa •••• 1111',
+                          tokenizationData: {
+                            type: 'PAYMENT_GATEWAY',
+                            token: '{"id": "tok_123"}',
+                          },
+                          type: 'CARD',
+                          info: {
+                            cardNetwork: 'VISA',
+                            cardDetails: '1111',
+                            billingAddress: {
+                              address3: '',
+                              sortingCode: '',
+                              address2: '',
+                              countryCode: 'US',
+                              address1: '1600 Amphitheatre Parkway',
+                              postalCode: '94043',
+                              name: 'John Smith',
+                              locality: 'Mountain View',
+                              administrativeArea: 'CA',
+                            },
+                          },
+                        },
+                      },
                       gateway_code: 'gateway_123',
                     }
                   });


### PR DESCRIPTION
There are certain conditions in which Recurly needs the full `paymentData` from the Google response.