### PR TITLE
Fix Tiered Unit Pricing Labels

### DIFF
--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -168,29 +168,25 @@ export default class Calculations {
       // exclude usage addons
       if (addon.add_on_type !== 'fixed') return;
 
-      const selectedQuantity = find(this.items.addons, { code: addon.code })?.quantity;
+      const selectedQuantity = find(this.items.addons, { code: addon.code })?.quantity || 0;
 
-      let price;
+      let unitPrice; // Price per unit, displayed on the label
+      let totalPrice; // Total price for the addon
+
       if (isTieredAddOn(addon)) {
-        price = getTieredPricingUnitAmount(addon, selectedQuantity, this.price.currency.code);
+        const currencyCode = this.pricing.currencyCode;
+        totalPrice = getTieredPricingTotal(addon, selectedQuantity, currencyCode);
+        unitPrice = getTieredPricingUnitAmount(addon, selectedQuantity, currencyCode);
       } else {
-        price = addon.price[this.items.currency].unit_amount;
+        unitPrice = addon.price[this.items.currency].unit_amount;
+        totalPrice = unitPrice * selectedQuantity;
       }
-      this.price.base.addons[addon.code] = price;
 
-      this.price.addons[addon.code] = price; // DEPRECATED
+      this.price.base.addons[addon.code] = unitPrice;
+      this.price.addons[addon.code] = totalPrice; // DEPRECATED
 
-      if (selectedQuantity) {
-        if (isTieredAddOn(addon)) {
-          const currencyCode = this.pricing.currencyCode;
-          price = getTieredPricingTotal(addon, selectedQuantity, currencyCode);
-        } else {
-          price = price * selectedQuantity;
-        }
-
-        if (!this.isTrial()) this.price.now.addons += price;
-        this.price.next.addons += price;
-      }
+      if (!this.isTrial()) this.price.now.addons += totalPrice;
+      this.price.next.addons += totalPrice;
     });
   }
 

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -3,7 +3,7 @@ import find from 'component-find';
 import isEmpty from 'lodash.isempty';
 import decimalizeMember from '../../../util/decimalize-member';
 import taxRound from '../../../util/tax-round';
-import { getTieredPricingTotal, isTieredAddOn } from './tiered-pricing-calculator';
+import { getTieredPricingTotal, getTieredPricingUnitAmount, isTieredAddOn } from './tiered-pricing-calculator';
 
 /**
  * Subscription pricing calculation handler
@@ -168,12 +168,18 @@ export default class Calculations {
       // exclude usage addons
       if (addon.add_on_type !== 'fixed') return;
 
-      let price = addon.price[this.items.currency].unit_amount;
+      const selectedQuantity = find(this.items.addons, { code: addon.code })?.quantity;
 
+      let price;
+      if (isTieredAddOn(addon)) {
+        price = getTieredPricingUnitAmount(addon, selectedQuantity, this.price.currency.code);
+      } else {
+        price = addon.price[this.items.currency].unit_amount;
+      }
       this.price.base.addons[addon.code] = price;
+
       this.price.addons[addon.code] = price; // DEPRECATED
 
-      const selectedQuantity = find(this.items.addons, { code: addon.code })?.quantity;
       if (selectedQuantity) {
         if (isTieredAddOn(addon)) {
           const currencyCode = this.pricing.currencyCode;

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -145,9 +145,7 @@ export default class SubscriptionPricing extends Pricing {
 
       if (quantity === 0) {
         this.remove({ addons: addonCode });
-      }
-
-      if (addon) {
+      } else if (addon) {
         addon.quantity = quantity;
       } else {
         addon = JSON.parse(JSON.stringify(planAddon));

--- a/lib/recurly/pricing/subscription/tiered-pricing-calculator.js
+++ b/lib/recurly/pricing/subscription/tiered-pricing-calculator.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import find from 'component-find';
 
 /**
  * 
@@ -117,4 +118,16 @@ export function getTieredPricingTotal (
     },
     initialUnitAmount,
   );
+}
+
+/**
+ * returns the unit amount for a tiered pricing model in the current tier based on selectedNumUnits
+ * @param {object} addOn
+ * @param {int} selectedNumUnits
+ * @param {string} currencyCode
+ * @returns number
+ */
+export function getTieredPricingUnitAmount (addOn, selectedNumUnits, currencyCode) {
+  const tier = find(addOn.tiers, (tier) => (selectedNumUnits || 1) <= tier.ending_quantity);
+  return find(tier.currencies, (currency) => currency.currency_code === currencyCode).unit_amount;
 }

--- a/test/server/fixtures/plans/tiered-plan.json
+++ b/test/server/fixtures/plans/tiered-plan.json
@@ -13,93 +13,119 @@
     "length": 1
   },
   "tax_exempt": true,
-  "addons": [{
-    "code": "flat",
-    "name": "flat",
-    "quantity": 1,
-    "add_on_type": "fixed",
-    "optional": true,
-    "tiers": [],
-    "tier_type": "flat",
-    "price": {
-      "USD": {
-        "unit_amount": 1.0
+  "addons": [
+    {
+      "code": "flat",
+      "name": "flat",
+      "quantity": 1,
+      "add_on_type": "fixed",
+      "optional": true,
+      "tiers": [],
+      "tier_type": "flat",
+      "price": {
+        "USD": {
+          "unit_amount": 1.0
+        }
+      }
+    },
+    {
+      "code": "tiered",
+      "name": "tiered",
+      "quantity": 1,
+      "add_on_type": "fixed",
+      "optional": true,
+      "tiers": [
+        {
+          "ending_quantity": 5,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 2.00
+            }
+          ]
+        },
+        {
+          "ending_quantity": 999999999,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 4.00
+            }
+          ]
+        }
+      ],
+      "tier_type": "tiered",
+      "price": {
+        "USD": {
+          "unit_amount": 4.00
+        }
+      }
+    },
+    {
+      "code": "volume",
+      "name": "volume",
+      "quantity": 1,
+      "add_on_type": "fixed",
+      "optional": true,
+      "tiers": [
+        {
+          "ending_quantity": 5,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 2.00
+            }
+          ]
+        },
+        {
+          "ending_quantity": 999999999,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 4.00
+            }
+          ]
+        }
+      ],
+      "tier_type": "volume",
+      "price": {
+        "USD": {
+          "unit_amount": 4.00
+        }
+      }
+    },
+    {
+      "code": "stairstep",
+      "name": "stairstep",
+      "quantity": 1,
+      "add_on_type": "fixed",
+      "optional": true,
+      "tiers": [
+        {
+          "ending_quantity": 5,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 2.00
+            }
+          ]
+        },
+        {
+          "ending_quantity": 999999999,
+          "currencies": [
+            {
+              "currency_code": "USD",
+              "unit_amount": 4.00
+            }
+          ]
+        }
+      ],
+      "tier_type": "stairstep",
+      "price": {
+        "USD": {
+          "unit_amount": 4.00
+        }
       }
     }
-  }, {
-    "code": "tiered",
-    "name": "tiered",
-    "quantity": 1,
-    "add_on_type": "fixed",
-    "optional": true,
-    "tiers": [{
-      "ending_quantity": 5,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 2.00
-      }]
-    }, {
-      "ending_quantity": 999999999,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 4.00
-      }]
-    }],
-    "tier_type": "tiered",
-    "price": {
-      "USD": {
-        "unit_amount": 4.00
-      }
-    }
-  }, {
-    "code": "volume",
-    "name": "volume",
-    "quantity": 1,
-    "add_on_type": "fixed",
-    "optional": true,
-    "tiers": [{
-      "ending_quantity": 5,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 2.00
-      }]
-    }, {
-      "ending_quantity": 999999999,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 4.00
-      }]
-    }],
-    "tier_type": "volume",
-    "price": {
-      "USD": {
-        "unit_amount": 4.00
-      }
-    }
-  }, {
-    "code": "stairstep",
-    "name": "stairstep",
-    "quantity": 1,
-    "add_on_type": "fixed",
-    "optional": true,
-    "tiers": [{
-      "ending_quantity": 5,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 2.00
-      }]
-    }, {
-      "ending_quantity": 999999999,
-      "currencies": [{
-        "currency_code": "USD",
-        "unit_amount": 4.00
-      }]
-    }],
-    "tier_type": "stairstep",
-    "price": {
-      "USD": {
-        "unit_amount": 4.00
-      }
-    }
-  }]
+  ]
 }

--- a/test/unit/pricing/subscription/tiered-pricing-calculator.test.js
+++ b/test/unit/pricing/subscription/tiered-pricing-calculator.test.js
@@ -1,9 +1,12 @@
 import assert from 'assert';
-import { getTieredPricingTotal } from '../../../../lib/recurly/pricing/subscription/tiered-pricing-calculator';
+import {
+  getTieredPricingTotal,
+  getTieredPricingUnitAmount
+} from '../../../../lib/recurly/pricing/subscription/tiered-pricing-calculator';
 import { initRecurly } from '../../support/helpers';
 import TIERED_PLAN from '../../../server/fixtures/plans/tiered-plan.json';
 
-describe('Recurly.Pricing.Subscription.TieredPricingCalendar', function () {
+describe('Recurly.Pricing.Subscription.TieredPricingCalculator', function () {
   beforeEach(function () {
     this.recurly = initRecurly();
     this.pricing = this.recurly.Pricing.Subscription();
@@ -29,6 +32,30 @@ describe('Recurly.Pricing.Subscription.TieredPricingCalendar', function () {
       assert.strictEqual(getTieredPricingTotal(volumeAddon, 2, 'USD'), 4.00);
       assert.strictEqual(getTieredPricingTotal(volumeAddon, 6, 'USD'), 24.00);
       done();
+    });
+
+    describe('unit pricing for current unit amount', () => {
+      it('should return the current tier price for tiered pricing', function (done) {
+        const tieredAddon = TIERED_PLAN.addons.filter((addon) => { return addon.code === 'tiered'; })[0];
+
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 1, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 2, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 5, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 6, 'USD'), 4.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 50, 'USD'), 4.00);
+        done();
+      });
+
+      it('should return the current tier price for stairstep pricing', function (done) {
+        const tieredAddon = TIERED_PLAN.addons.filter((addon) => { return addon.code === 'stairstep'; })[0];
+
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 1, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 2, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 5, 'USD'), 2.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 6, 'USD'), 4.00);
+        assert.strictEqual(getTieredPricingUnitAmount(tieredAddon, 50, 'USD'), 4.00);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes addressed in this PR:
* Fix prices calculated for each tiered addon, now considering the `quantity` amount for inputs using `data-recurly="addon_price"`.
  Before this change the price for addons in these points were being calculated using the largest tier:
  * `subscription.price.base.addons['addon-code']` 
  * `subscription.price.addons['addon-code']`

* Fix total and subtotal calculation when having multiple addons for the same subscription

