### PR TITLE
Installing `httplib2` and `crcmod` as needed by `gsutil` in the last build step

### DIFF
--- a/.travis-pre.sh
+++ b/.travis-pre.sh
@@ -1,2 +1,3 @@
 # Disables non-blocking stdout to prevent cat write errors
 python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+pip install httplib2 crcmod


### PR DESCRIPTION
Recent [builds](https://app.travis-ci.com/github/recurly/recurly-js/jobs/596366679) in TravisCI are failing in the "Publish Artifacts" step with this error:
```
The command "make build" exited with 0.
1.13s$ gsutil cp -Z build/* $GCS_BUCKET_URL/$TRAVIS_COMMIT/
Traceback (most recent call last):
  File "/usr/lib/google-cloud-sdk/platform/gsutil/gsutil", line 21, in <module>
    gsutil.RunMain()
  File "/usr/lib/google-cloud-sdk/platform/gsutil/gsutil.py", line 121, in RunMain
    import gslib.__main__
  File "/usr/lib/google-cloud-sdk/platform/gsutil/gslib/__main__.py", line 83, in <module>
    import httplib2
ModuleNotFoundError: No module named 'httplib2'
The command "gsutil cp -Z build/* $GCS_BUCKET_URL/$TRAVIS_COMMIT/" exited with 1.
cache.2
```

This PRs adds the missing PIP packages (`httplib2` and `crcmod`) to the build enviroment.
