### PR TITLE
feat(apple pay): update tax when billing/shipping contact changes

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -186,12 +186,17 @@ export class ApplePay extends Emitter {
    */
   begin () {
     if (this.initError) return this.error('apple-pay-init-error', { err: this.initError });
+    if (this.config.pricing) {
+      const { address, shippingAddress } = this.config.pricing.items;
+      this._savedPricingState = { address, shippingAddress };
+    }
+
     delete this._session;
     this.session.begin();
   }
 
   /**
-   * Updates line items and total price on pricing module changes
+   * Updates line items and total price from the pricing module
    *
    * @param  {Object} price Pricing.price
    * @private
@@ -243,6 +248,14 @@ export class ApplePay extends Emitter {
     });
   }
 
+  setAddress (addressType, contact, done) {
+    if (!contact || !this.config.pricing) return done?.();
+
+    const address = transformAddress(contact, { to: 'address', except: ['emailAddress'] });
+
+    return this.config.pricing[addressType](address).done(done);
+  }
+
   /**
    * Handles payment method selection
    *
@@ -254,9 +267,11 @@ export class ApplePay extends Emitter {
 
     this.emit('paymentMethodSelected', event);
 
-    this.session.completePaymentMethodSelection({
-      newTotal: this.finalTotalLineItem,
-      newLineItems: this.lineItems,
+    this.setAddress('address', event.paymentMethod.billingContact, () => {
+      this.session.completePaymentMethodSelection({
+        newTotal: this.finalTotalLineItem,
+        newLineItems: this.lineItems,
+      });
     });
   }
 
@@ -267,14 +282,14 @@ export class ApplePay extends Emitter {
    * @private
    */
   onShippingContactSelected (event) {
-    const newShippingMethods = [];
-
     this.emit('shippingContactSelected', event);
 
-    this.session.completeShippingContactSelection({
-      newTotal: this.finalTotalLineItem,
-      newLineItems: this.lineItems,
-      newShippingMethods,
+    this.setAddress('shippingAddress', event.shippingContact, () => {
+      this.session.completeShippingContactSelection({
+        newTotal: this.finalTotalLineItem,
+        newLineItems: this.lineItems,
+        newShippingMethods: [],
+      });
     });
   }
 
@@ -290,6 +305,7 @@ export class ApplePay extends Emitter {
     this.session.completeShippingMethodSelection({
       newTotal: this.finalTotalLineItem,
       newLineItems: this.lineItems,
+      newShippingMethods: [],
     });
   }
 
@@ -339,8 +355,7 @@ export class ApplePay extends Emitter {
    */
   onCancel (event) {
     debug('User canceled Apple Pay payment', event);
-
-    this.emit('cancel', event);
+    restorePricing(this.config.pricing, this._savedPricingState, () => this.emit('cancel', event));
   }
 
   /**
@@ -376,4 +391,23 @@ export class ApplePay extends Emitter {
       ...transformAddress(billingContact, { to: 'address', except: ['emailAddress'] }),
     };
   }
+}
+
+function restorePricing (pricing, state, done) {
+  if (!pricing) return done();
+
+  let reprice = false;
+
+  if (pricing.items.address !== state.address) {
+    pricing.items.address = state.address;
+    reprice = true;
+  }
+
+  if (pricing.items.shippingAddress !== state.shippingAddress) {
+    pricing.items.shippingAddress = state.shippingAddress;
+    reprice = true;
+  }
+
+  if (reprice) pricing.reprice(done);
+  else done();
 }

--- a/lib/recurly/apple-pay/util/transform-address.js
+++ b/lib/recurly/apple-pay/util/transform-address.js
@@ -31,7 +31,7 @@ const CONTACT_MAP = {
  * @param {string} options.except properties to exclude
  * @return {Object} the transform result
  */
-export function transformAddress (source, { to = 'contact', except = [], map = CONTACT_MAP }) {
+export function transformAddress (source, { to = 'contact', except = [], map = CONTACT_MAP } = {}) {
   if (isEmpty(source)) return {};
 
   return Object.keys(map).reduce((target, addressField) => {

--- a/lib/recurly/pricing/index.js
+++ b/lib/recurly/pricing/index.js
@@ -198,13 +198,13 @@ export class Pricing extends Emitter {
    * @return {Function} PricingPromise handler
    * @private
    */
-  itemUpdateFactory (name, object) {
+  itemUpdateFactory (name, object, { eventName = name } = {}) {
     return (resolve) => {
       if (JSON.stringify(object) === JSON.stringify(this.items[name])) {
         return resolve(this.items[name]);
       }
       this.items[name] = object;
-      this.resolveAndEmit(`set.${name}`, object, resolve);
+      this.resolveAndEmit(`set.${eventName}`, object, resolve);
     };
   }
 

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -84,7 +84,7 @@ export default class Calculations {
   /**
    * Calculates tax
    *
-   * tax info precedence: `tax` > `shipping_address` > `address`
+   * tax info precedence: `tax` > `shippingAddress` > `address`
    *
    * @param {Function} done
    * @private
@@ -101,7 +101,7 @@ export default class Calculations {
     }
 
     // Tax the shipping address if present, or
-    const taxAddress = this.items.shipping_address || this.items.address;
+    const taxAddress = this.items.shippingAddress || this.items.address;
     const taxInfo = Object.assign({}, taxAddress, this.items.tax);
 
     if (!isEmpty(taxInfo)) {

--- a/lib/recurly/pricing/subscription/index.js
+++ b/lib/recurly/pricing/subscription/index.js
@@ -275,7 +275,10 @@ export default class SubscriptionPricing extends Pricing {
    * @public
    */
   shippingAddress (address, done) {
-    return new PricingPromise(this.itemUpdateFactory('shipping_address', address), this).nodeify(done);
+    return new PricingPromise(
+      this.itemUpdateFactory('shippingAddress', address, { eventName: 'shipping_address' }),
+      this,
+    ).nodeify(done);
   }
 
   /**

--- a/test/unit/pricing/checkout/attachment.test.js
+++ b/test/unit/pricing/checkout/attachment.test.js
@@ -90,11 +90,11 @@ describe('CheckoutPricing#attach', function () {
         };
 
         it('does not set the shipping address', function (done) {
-          assert(typeof this.pricing.items.shipping_address === 'undefined');
+          assert(typeof this.pricing.items.shippingAddress === 'undefined');
           this.pricing.on('set.address', () => {
             assert.equal(this.pricing.items.address.country, 'US');
             assert.equal(this.pricing.items.address.postal_code, '94129');
-            assert.equal(this.pricing.items.shipping_address, undefined);
+            assert.equal(this.pricing.items.shippingAddress, undefined);
             done();
           });
         });

--- a/test/unit/pricing/subscription/attachment.test.js
+++ b/test/unit/pricing/subscription/attachment.test.js
@@ -72,10 +72,10 @@ describe('Recurly.Pricing.attach', function () {
       };
 
       it('sets the shipping address', function (done) {
-        assert(typeof this.pricing.items.shipping_address === 'undefined');
+        assert(typeof this.pricing.items.shippingAddress === 'undefined');
         this.pricing.on('set.shipping_address', () => {
-          assert.equal(this.pricing.items.shipping_address.country, 'US');
-          assert.equal(this.pricing.items.shipping_address.postal_code, '94129');
+          assert.equal(this.pricing.items.shippingAddress.country, 'US');
+          assert.equal(this.pricing.items.shippingAddress.postal_code, '94129');
           done();
         });
       });
@@ -90,11 +90,11 @@ describe('Recurly.Pricing.attach', function () {
         };
 
         it('does not set the shipping address', function (done) {
-          assert(typeof this.pricing.items.shipping_address === 'undefined');
+          assert(typeof this.pricing.items.shippingAddress === 'undefined');
           this.pricing.on('set.address', () => {
             assert.equal(this.pricing.items.address.country, 'US');
             assert.equal(this.pricing.items.address.postal_code, '94129');
-            assert.equal(this.pricing.items.shipping_address, undefined);
+            assert.equal(this.pricing.items.shippingAddress, undefined);
             done();
           });
         });


### PR DESCRIPTION
When `options.pricing` is supplied to `recurly.ApplePay`, tax will be recalculated and stored based on the client's selection on the payment sheet for both billing and shipping contacts (shipping requires collecting the `postalAddress`).

Internally this changes the `SubscriptionPricing#items` schema from `items.shipping_address` to `items.shippingAddress` to match the `CheckoutPricing#items` schema. It does not change the `set.shipping_address` event that is emitted, however.