### PR TITLE
feat(apple pay): allow for supportedNetworks selection

### DIFF
--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -1,3 +1,4 @@
+import intersection from 'intersect';
 import errors from '../../errors';
 import filterSupportedNetworks from './filter-supported-networks';
 import { lineItem, isLineItem } from './apple-pay-line-item';
@@ -97,7 +98,10 @@ function applyRemoteConfig (paymentRequest, cb) {
     if ('subdomain' in info) paymentRequest.applicationData = btoa(info.subdomain);
 
     paymentRequest.merchantCapabilities = info.merchantCapabilities || [];
-    paymentRequest.supportedNetworks = filterSupportedNetworks(info.supportedNetworks || []);
+    const supportedNetworks = paymentRequest.supportedNetworks
+      ? intersection(info.supportedNetworks, paymentRequest.supportedNetworks)
+      : info.supportedNetworks;
+    paymentRequest.supportedNetworks = filterSupportedNetworks(supportedNetworks);
 
     cb(null, paymentRequest);
   };

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -437,7 +437,7 @@ function applePayTest (integrationType, requestMethod) {
       });
 
       it('sets other ApplePayPaymentRequest options and does not include configuration options', function (done) {
-        let applePay = this.recurly.ApplePay(merge({}, validOpts, {
+        const applePay = this.recurly.ApplePay(merge({}, validOpts, {
           requiredShippingContactFields: ['email'],
           supportedCountries: ['US'],
         }));
@@ -476,6 +476,16 @@ function applePayTest (integrationType, requestMethod) {
         it('assigns supportedNetworks', function (done) {
           this.applePay.ready(() => {
             assert.deepEqual(this.applePay.session.supportedNetworks, infoFixture.supportedNetworks);
+            done();
+          });
+        });
+
+        it('limits the supportedNetworks to the configuration', function (done) {
+          const applePay = this.recurly.ApplePay(merge({}, validOpts, {
+            supportedNetworks: ['visa'],
+          }));
+          applePay.ready(() => {
+            assert.deepEqual(applePay.session.supportedNetworks, ['visa']);
             done();
           });
         });

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -110,7 +110,13 @@ export type ApplePayPaymentRequest = {
   /**
    * Billing contact information for the user.
    */
-  billingContact: ApplePayPaymentContact;
+  billingContact?: ApplePayPaymentContact;
+
+  /**
+   * The payment networks the merchant supports. Only selects those networks that intersect with the merchant's
+   * payment gateways configured in Recurly.
+   */
+  supportedNetworks?: string;
 
   /**
    * The fields of shipping information the user must provide to fulfill the order.
@@ -120,7 +126,7 @@ export type ApplePayPaymentRequest = {
   /**
    * Shipping contact information for the user.
    */
-  shippingContact: ApplePayPaymentContact;
+  shippingContact?: ApplePayPaymentContact;
 
   /**
    * A set of line items that explain recurring payments and additional charges and discounts.


### PR DESCRIPTION
Opens up the `supportedNetworks` option for the merchant to choose which networks they would like to accept. This list must be a subset of the merchant's accepted networks in Recurly.