### PR TITLE
feat(apple pay): populate contacts with pricing addresses

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -1,10 +1,13 @@
 import Emitter from 'component-emitter';
 import errors from '../errors';
+import { normalize } from '../../util/normalize';
+import { NON_ADDRESS_FIELDS } from '../token';
 import { Pricing } from '../pricing';
 import PricingPromise from '../pricing/promise';
 import { lineItem } from './util/apple-pay-line-item';
+import { transformAddress } from './util/transform-address';
 import buildApplePayPaymentRequest from './util/build-apple-pay-payment-request';
-import { transformAddress, normalizeForm } from './util/transform-address';
+import finalizeApplePayPaymentRequest from './util/finalize-apple-pay-payment-request';
 
 const debug = require('debug')('recurly:apple-pay');
 
@@ -61,23 +64,8 @@ export class ApplePay extends Emitter {
    */
   get session () {
     if (this._session) return this._session;
-    let paymentRequest = this._paymentRequest;
 
-    if (this.config.form) {
-      const { billingContact, shippingContact } = paymentRequest;
-      const {
-        billingContact: formBillingContact,
-        shippingContact: formShippingContact, tokenData,
-      } = normalizeForm(this.config.form);
-      this.tokenData = tokenData;
-
-      paymentRequest = {
-        ...paymentRequest,
-        ...(!billingContact && formBillingContact && { billingContact: formBillingContact }),
-        ...(!shippingContact && formShippingContact && { shippingContact: formShippingContact }),
-      };
-    }
-
+    const paymentRequest = finalizeApplePayPaymentRequest(this._paymentRequest, this.config);
     debug('Creating new Apple Pay session', paymentRequest);
 
     const session = new window.ApplePaySession(MINIMUM_SUPPORTED_VERSION, paymentRequest);
@@ -387,7 +375,7 @@ export class ApplePay extends Emitter {
     return {
       paymentData,
       paymentMethod,
-      ...(this.tokenData && this.tokenData),
+      ...(this.config.form && normalize(this.config.form, NON_ADDRESS_FIELDS, { parseCard: false }).values),
       ...transformAddress(billingContact, { to: 'address', except: ['emailAddress'] }),
     };
   }

--- a/lib/recurly/apple-pay/util/finalize-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/finalize-apple-pay-payment-request.js
@@ -1,0 +1,61 @@
+import { normalize } from '../../../util/normalize';
+import { ADDRESS_FIELDS } from '../../token';
+import { transformAddress, BILLING_CONTACT_MAP } from './transform-address';
+
+/**
+ * builds the billingContact from either the pricing address or an address object
+ *
+ * @param {Pricing} pricing
+ * @param {object} address address fields
+ * @return {object} billingContact
+ * @private
+ */
+function buildBillingContact (pricing, address) {
+  address = pricing?.items.address ?? address;
+  if (address) return transformAddress(address, { map: BILLING_CONTACT_MAP });
+}
+
+/**
+ * builds the shipping from either the pricing shipping address or an address object.
+ * includes the pricing address phone number if present.
+ *
+ * @param {Pricing} pricing
+ * @param {object} address address fields
+ * @return {object} shippingContact
+ * @private
+ */
+function buildShippingContact (pricing, address) {
+  const phone = pricing?.items.address?.phone;
+  address = phone || pricing?.items.shippingAddress
+    ? { phone, ...pricing.items.shippingAddress }
+    : address;
+
+  if (address) return transformAddress(address);
+}
+
+/**
+ * builds an ApplePaySession with the billing and shipping contact's from the config
+ *
+ * @param {number} version Apple Pay on the Web version
+ * @param {object} paymentRequest the ApplePayPaymentRequest object
+ * @param {object} config the ApplePay config
+ * @return {object} ApplePaySession
+ * @private
+ */
+export default function finalizeApplePayPaymentRequest (paymentRequest, config) {
+  if (paymentRequest.billingContact && paymentRequest.shippingContact) return paymentRequest;
+
+  const formAddress = config.form
+    ? normalize(config.form, ADDRESS_FIELDS, { parseCard: false }).values
+    : null;
+  const formPhone = formAddress?.phone ? { phone: formAddress.phone } : null;
+
+  const billingContact = paymentRequest.billingContact ?? buildBillingContact(config.pricing, formAddress);
+  const shippingContact = paymentRequest.shippingContact ?? buildShippingContact(config.pricing, formPhone);
+
+  return {
+    ...paymentRequest,
+    ...(billingContact && { billingContact }),
+    ...(shippingContact && { shippingContact }),
+  };
+}

--- a/lib/recurly/apple-pay/util/transform-address.js
+++ b/lib/recurly/apple-pay/util/transform-address.js
@@ -1,8 +1,6 @@
 import isEmpty from 'lodash.isempty';
-import { normalize } from '../../../util/normalize';
-import { ADDRESS_FIELDS, NON_ADDRESS_FIELDS } from '../../token';
 
-const BILLING_CONTACT_MAP = {
+export const BILLING_CONTACT_MAP = {
   first_name: 'givenName',
   last_name: 'familyName',
   address1: { field: 'addressLines', index: 0 },
@@ -13,7 +11,7 @@ const BILLING_CONTACT_MAP = {
   country: 'countryCode',
 };
 
-const SHIPPING_CONTACT_MAP = {
+export const SHIPPING_CONTACT_MAP = {
   email: 'emailAddress',
   phone: 'phoneNumber',
 };
@@ -32,9 +30,9 @@ const CONTACT_MAP = {
  * @return {Object} the transform result
  */
 export function transformAddress (source, { to = 'contact', except = [], map = CONTACT_MAP } = {}) {
-  if (isEmpty(source)) return {};
+  if (isEmpty(source)) return null;
 
-  return Object.keys(map).reduce((target, addressField) => {
+  const target = Object.keys(map).reduce((target, addressField) => {
     const contactField = map[addressField];
     const sourceField = to === 'contact' ? addressField : contactField;
     const targetField = to === 'address' ? addressField : contactField;
@@ -56,19 +54,6 @@ export function transformAddress (source, { to = 'contact', except = [], map = C
 
     return target;
   }, {});
-}
 
-export function normalizeForm (form) {
-  if (!form) return {};
-
-  const address = normalize(form, ADDRESS_FIELDS, { parseCard: false }).values;
-  const billingContact = transformAddress(address, { map: BILLING_CONTACT_MAP });
-  const shippingContact = transformAddress(address, { map: SHIPPING_CONTACT_MAP });
-  const tokenData = normalize(form, NON_ADDRESS_FIELDS, { parseCard: false }).values;
-
-  return {
-    billingContact,
-    shippingContact,
-    tokenData,
-  };
+  return isEmpty(target) ? null : target;
 }


### PR DESCRIPTION
Pricing is the recommended way of integrating with Recurly.js, so use the `address` and `shippingAddress` properties of the `price` to populate the `billingContact` and `shippingContact` over the `form` address. The `address.phone` is part of the `shippingContact` in Apple terms so it shows in the payment sheet.