### PR TITLE
fix(apple pay): emit events when restore pricing addresses

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -396,18 +396,11 @@ export class ApplePay extends Emitter {
 function restorePricing (pricing, state, done) {
   if (!pricing) return done();
 
-  let reprice = false;
+  let promise;
+  const { address, shippingAddress } = state;
 
-  if (pricing.items.address !== state.address) {
-    pricing.items.address = state.address;
-    reprice = true;
-  }
+  if (pricing.items.address !== address) promise = (promise || pricing).address(address);
+  if (pricing.items.shippingAddress !== shippingAddress) promise = (promise || pricing).shippingAddress(shippingAddress);
 
-  if (pricing.items.shippingAddress !== state.shippingAddress) {
-    pricing.items.shippingAddress = state.shippingAddress;
-    reprice = true;
-  }
-
-  if (reprice) pricing.reprice(done);
-  else done();
+  return promise ? promise.done(done) : done();
 }


### PR DESCRIPTION
When restoring the `address` and `shippingAddress` on `pricing` after the user cancels, we do not emit the change event if the addresses were to change. This fixes that so we are consistent in changing the addresses during the AP checkout flow.