### PR TITLE
feat(apple pay): add support for `recurringPaymentRequest`, move to `options.paymentRequest`

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -29,8 +29,10 @@ const I18N = {
  * @param {Recurly} options.recurly
  * @param {String} options.country
  * @param {String} options.currency
- * @param {String|Object} [options.total] either in dollar format, '1.00', or an ApplePayLineItem object that represents the total for the payment. Optional and discarded if 'pricing' is supplied
- * @param {String} [options.label] The short, localized description of the total charge. Deprecated, use 'i18n.totalLineItemLabel' if not using an ApplePayLineItem as the total
+ * @param {String|Object} [options.total] total for the payment in dollar format, eg: '1.00'. Optional and discarded if 'pricing' is supplied
+ * @param {String} [options.label] The short, localized description of the total charge. Deprecated, use 'i18n.totalLineItemLabel'
+ * @param {Boolean} [options.recurring] whether or not the total line item is recurring
+ * @param {Object} [options.paymentRequest] an ApplePayPaymentRequest
  * @param {HTMLElement} [options.form] to provide additional customer data
  * @param {Pricing} [options.pricing] to provide line items and total from Pricing
  * @param {Boolean} [options.enforceVersion] to ensure that the client supports the minimum version to support required fields
@@ -92,10 +94,8 @@ export class ApplePay extends Emitter {
    * @private
    */
   get lineItems () {
-    if (!this._ready) return [];
-
     // Clone configured line items
-    return [].concat(this._paymentRequest.lineItems);
+    return this._paymentRequest?.lineItems ? [].concat(this._paymentRequest.lineItems) : [];
   }
 
   /**
@@ -103,9 +103,7 @@ export class ApplePay extends Emitter {
    * @private
    */
   get totalLineItem () {
-    if (!this._ready) return {};
-
-    return this._paymentRequest.total;
+    return this._paymentRequest?.total ? this._paymentRequest.total : {};
   }
 
   /**
@@ -135,30 +133,23 @@ export class ApplePay extends Emitter {
    * @private
    */
   configure (options) {
-    if (options.recurly) {
-      this.recurly = options.recurly;
-      delete options.recurly;
-    } else return this.initError = this.error('apple-pay-factory-only');
+    if (options.recurly) this.recurly = options.recurly;
+    else return this.initError = this.error('apple-pay-factory-only');
 
-    if (options.form) {
-      this.config.form = options.form;
-      delete options.form;
-    }
+    if (options.form) this.config.form = options.form;
+    if (options.recurring) this.config.recurring = options.recurring;
 
     this.config.i18n = {
       ...I18N,
       ...(options.label && { totalLineItemLabel: options.label }),
       ...options.i18n,
     };
-    delete options.label;
-    delete options.i18n;
 
     if (options.pricing instanceof PricingPromise) {
       this.config.pricing = options.pricing.pricing;
     } else if (options.pricing instanceof Pricing) {
       this.config.pricing = options.pricing;
     }
-    delete options.pricing;
 
     buildApplePayPaymentRequest(this, options, (err, paymentRequest) => {
       if (err) return this.initError = this.error(err);
@@ -198,9 +189,9 @@ export class ApplePay extends Emitter {
    * @private
    */
   onPricingChange () {
-    const { pricing } = this.config;
+    const { pricing, recurring } = this.config;
 
-    this._paymentRequest.total = lineItem(this.config.i18n.totalLineItemLabel, pricing.totalNow);
+    this._paymentRequest.total = lineItem(this.config.i18n.totalLineItemLabel, pricing.totalNow, { recurring });
     this._paymentRequest.lineItems = [];
 
     if (!pricing.hasPrice) return;

--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -80,6 +80,14 @@ export class ApplePay extends Emitter {
   }
 
   /**
+   * @return {Object} recurring payment request for display on payment sheet
+   * @private
+   */
+  get recurringPaymentRequest () {
+    return this._paymentRequest?.recurringPaymentRequest;
+  }
+
+  /**
    * @return {Array} subtotal line items for display on payment sheet
    * @private
    */
@@ -259,6 +267,7 @@ export class ApplePay extends Emitter {
       this.session.completePaymentMethodSelection({
         newTotal: this.finalTotalLineItem,
         newLineItems: this.lineItems,
+        ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
       });
     });
   }
@@ -277,6 +286,7 @@ export class ApplePay extends Emitter {
         newTotal: this.finalTotalLineItem,
         newLineItems: this.lineItems,
         newShippingMethods: [],
+        ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
       });
     });
   }
@@ -294,6 +304,7 @@ export class ApplePay extends Emitter {
       newTotal: this.finalTotalLineItem,
       newLineItems: this.lineItems,
       newShippingMethods: [],
+      ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
     });
   }
 

--- a/lib/recurly/apple-pay/util/apple-pay-line-item.js
+++ b/lib/recurly/apple-pay/util/apple-pay-line-item.js
@@ -6,15 +6,10 @@ import decimalize from '../../../util/decimalize';
  * @param  {Number} amount
  * @return {object}
  */
-export function lineItem (label = '', amount = 0) {
-  return { label, amount: decimalize(amount) };
-}
-
-/**
- * Determine if the val is a valid ApplePayLineItem
- * @param {object} val
- * @return {boolean}
- */
-export function isLineItem (val) {
-  return typeof val === 'object' && val.label !== undefined && val.amount !== undefined;
+export function lineItem (label = '', amount = 0, { recurring = false } = {}) {
+  return {
+    label,
+    amount: decimalize(amount),
+    ...(recurring && { paymentTiming: 'recurring' }),
+  };
 }

--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -1,32 +1,25 @@
 import intersection from 'intersect';
 import errors from '../../errors';
 import filterSupportedNetworks from './filter-supported-networks';
-import { lineItem, isLineItem } from './apple-pay-line-item';
+import { lineItem } from './apple-pay-line-item';
 
 const REQUIRED_SHIPPING_FIELDS_VERSION = 6;
 
 function buildOrder (config, options, paymentRequest) {
-  if (!options.total) return errors('apple-pay-config-missing', { opt: 'total' });
+  if (!paymentRequest.total && !options.total) return errors('apple-pay-config-missing', { opt: 'total' });
 
-  const { total, lineItems = [], recurringPaymentRequest } = options;
-  ['total', 'lineItems'].forEach(k => delete options[k]);
-
-  if (isLineItem(total)) {
-    paymentRequest.total = total;
-    if (!recurringPaymentRequest && total.paymentTiming === 'recurring') {
-      paymentRequest.recurringPaymentRequest = {
-        paymentDescription: total.label,
-        regularBilling: total,
-      };
-    }
-  } else if (typeof total === 'object') {
-    const missing = (total.label === undefined) ? 'label' : 'amount';
-    return errors('apple-pay-config-missing', { opt: `total.${missing}` });
-  } else {
-    paymentRequest.total = lineItem(config.i18n.totalLineItemLabel, total);
+  let { total: totalLineItem } = paymentRequest;
+  if (!totalLineItem) {
+    const { recurring, total } = options;
+    paymentRequest.total = totalLineItem = lineItem(config.i18n.totalLineItemLabel, total, { recurring });
   }
 
-  paymentRequest.lineItems = lineItems;
+  if (!paymentRequest.recurringPaymentRequest && totalLineItem.paymentTiming === 'recurring') {
+    paymentRequest.recurringPaymentRequest = {
+      paymentDescription: totalLineItem.label,
+      regularBilling: totalLineItem,
+    };
+  }
 }
 
 /**
@@ -44,17 +37,16 @@ function buildOrder (config, options, paymentRequest) {
  */
 export default function buildApplePayPaymentRequest (applePay, options, cb) {
   const { recurly, config } = applePay;
-
-  const { currency: currencyCode, country: countryCode } = options;
-  if (!currencyCode) return cb(errors('apple-pay-config-missing', { opt: 'currency' }));
-  if (!countryCode) return cb(errors('apple-pay-config-missing', { opt: 'country' }));
-  ['currency', 'country'].forEach(k => delete options[k]);
-
-  let paymentRequest = {
-    currencyCode,
-    countryCode,
+  const paymentRequest = {
+    currencyCode: options.currency,
+    countryCode: options.country,
+    requiredShippingContactFields: options.requiredShippingContactFields, // deprecated
+    ...options.paymentRequest,
     requiredBillingContactFields: ['postalAddress'],
   };
+
+  if (!paymentRequest.currencyCode) return cb(errors('apple-pay-config-missing', { opt: 'currency' }));
+  if (!paymentRequest.countryCode) return cb(errors('apple-pay-config-missing', { opt: 'country' }));
 
   // The order is handled by pricing if set
   if (!config.pricing) {
@@ -63,14 +55,8 @@ export default function buildApplePayPaymentRequest (applePay, options, cb) {
   }
 
   if (options.enforceVersion &&
-      options.requiredShippingContactFields &&
+      paymentRequest.requiredShippingContactFields &&
       !window.ApplePaySession.supportsVersion(REQUIRED_SHIPPING_FIELDS_VERSION)) return cb(errors('apple-pay-not-supported'));
-  delete options.enforceVersion;
-
-  paymentRequest = {
-    ...options,
-    ...paymentRequest,
-  };
 
   recurly.request.get({
     route: '/apple_pay/info',

--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -8,11 +8,17 @@ const REQUIRED_SHIPPING_FIELDS_VERSION = 6;
 function buildOrder (config, options, paymentRequest) {
   if (!options.total) return errors('apple-pay-config-missing', { opt: 'total' });
 
-  const { total, lineItems = [] } = options;
+  const { total, lineItems = [], recurringPaymentRequest } = options;
   ['total', 'lineItems'].forEach(k => delete options[k]);
 
   if (isLineItem(total)) {
     paymentRequest.total = total;
+    if (!recurringPaymentRequest && total.paymentTiming === 'recurring') {
+      paymentRequest.recurringPaymentRequest = {
+        paymentDescription: total.label,
+        regularBilling: total,
+      };
+    }
   } else if (typeof total === 'object') {
     const missing = (total.label === undefined) ? 'label' : 'amount';
     return errors('apple-pay-config-missing', { opt: `total.${missing}` });
@@ -102,6 +108,15 @@ function applyRemoteConfig (paymentRequest, cb) {
       ? intersection(info.supportedNetworks, paymentRequest.supportedNetworks)
       : info.supportedNetworks;
     paymentRequest.supportedNetworks = filterSupportedNetworks(supportedNetworks);
+
+    const { recurringPaymentRequest } = paymentRequest;
+    if (recurringPaymentRequest) {
+      if (!recurringPaymentRequest.managementURL && !info.managementURL) {
+        return cb(errors('apple-pay-config-invalid', { opt: 'recurringPaymentRequest.managementURL' }));
+      } else if (!recurringPaymentRequest.managementURL) {
+        recurringPaymentRequest.managementURL = info.managementURL;
+      }
+    }
 
     cb(null, paymentRequest);
   };

--- a/test/server/fixtures/apple_pay/info.json
+++ b/test/server/fixtures/apple_pay/info.json
@@ -3,5 +3,6 @@
   "countries": ["US", "CA"],
   "currencies": ["USD", "CAD"],
   "merchantCapabilities": ["supportsCredit", "supports3DS", "supportsDebit"],
-  "supportedNetworks": ["visa", "amex"]
+  "supportedNetworks": ["visa", "amex"],
+  "managementURL": "https://example.com/account"
 }

--- a/test/types/apple-pay.ts
+++ b/test/types/apple-pay.ts
@@ -1,7 +1,7 @@
-import { ApplePayLineItem } from 'lib/apple-pay/native';
+import { ApplePayPaymentRequest, ApplePayLineItem } from 'lib/apple-pay/native';
 
 export default function applePay() {
-  const applePayDeprecated = recurly.ApplePay({
+  const applePaySimple = recurly.ApplePay({
     country: 'US',
     currency: 'USD',
     label: 'My Subscription',
@@ -18,9 +18,7 @@ export default function applePay() {
     recurringPaymentStartDate: new Date(),
   };
 
-  const applePay = recurly.ApplePay({
-    country: 'US',
-    currency: 'USD',
+  const paymentRequest: ApplePayPaymentRequest = {
     total,
     lineItems: [{ label: 'Subtotal', amount: '1.00' }],
     requiredShippingContactFields: ['email', 'phone'],
@@ -42,7 +40,12 @@ export default function applePay() {
       regularBilling: total,
       billingAgreement: 'Will recur forever',
     },
-    pricing: window.recurly.Pricing.Checkout()
+  };
+
+  const applePay = recurly.ApplePay({
+    country: 'US',
+    currency: 'USD',
+    paymentRequest,
   });
 
   applePay.ready(() => {});

--- a/test/types/apple-pay.ts
+++ b/test/types/apple-pay.ts
@@ -1,3 +1,5 @@
+import { ApplePayLineItem } from 'lib/apple-pay/native';
+
 export default function applePay() {
   const applePayDeprecated = recurly.ApplePay({
     country: 'US',
@@ -7,10 +9,19 @@ export default function applePay() {
     pricing: window.recurly.Pricing.Checkout()
   });
 
+  const total: ApplePayLineItem = {
+    label: 'My Subscription',
+    paymentTiming: 'recurring',
+    amount: '29.00',
+    recurringPaymentIntervalUnit: 'month',
+    recurringPaymentIntervalCount: 1,
+    recurringPaymentStartDate: new Date(),
+  };
+
   const applePay = recurly.ApplePay({
     country: 'US',
     currency: 'USD',
-    total: { label: 'My Subscription', amount: '29.00' },
+    total,
     lineItems: [{ label: 'Subtotal', amount: '1.00' }],
     requiredShippingContactFields: ['email', 'phone'],
     billingContact: {
@@ -25,6 +36,11 @@ export default function applePay() {
     shippingContact: {
       phoneNumber: '1231231234',
       emailAddress: 'ebrown@example.com'
+    },
+    recurringPaymentRequest: {
+      paymentDescription: 'A recurring subscription',
+      regularBilling: total,
+      billingAgreement: 'Will recur forever',
     },
     pricing: window.recurly.Pricing.Checkout()
   });

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -1,17 +1,45 @@
 import { Emitter } from '../emitter';
 import { CheckoutPricingInstance, CheckoutPricingPromise } from '../pricing/checkout';
-import { ApplePayPaymentRequest, ApplePayLineItem } from './native';
+import { ApplePayPaymentRequest } from './native';
+
+export type I18n = {
+  /**
+   * The short, localized description of the subtotal line item
+   */
+  subtotalLineItemLabel: string;
+
+  /**
+   * The short, localized description of the total line item
+   */
+  totalLineItemLabel: string;
+
+  /**
+   * The short, localized description of the discount line item
+   */
+  discountLineItemLabel: string;
+
+  /**
+   * The short, localized description of the tax line item
+   */
+  taxLineItemLabel: string;
+
+  /**
+   * The short, localized description of the gift card line item
+   */
+  giftCardLineItemLabel: string;
+};
 
 export type ApplePayConfig = {
   /**
-   * Your ISO 3166 country code (ex: ‘US’). This is your country code as the merchant.
+   * Your ISO 3166 country code (ex: ‘US’). This is your country code as the merchant. Required if not
+   * set in `options.paymentRequest.countryCode`.
    */
-  country: string;
+  country?: string;
 
   /**
-   * ISO 4217 purchase currency (ex: ‘USD’)
+   * ISO 4217 purchase currency (ex: ‘USD’). Required if not set in `options.paymentRequest.currencyCode`.
    */
-  currency: string;
+  currency?: string;
 
   /**
    * Purchase description to display in the Apple Pay payment sheet.
@@ -19,9 +47,20 @@ export type ApplePayConfig = {
   label?: string;
 
   /**
-   * Total cost to display in the Apple Pay payment sheet. Required if `options.pricing` is not provided.
+   * Total cost to display in the Apple Pay payment sheet. Required if `options.pricing` or
+   * `options.paymentRequest.total` is not provided.
    */
-  total?: string | ApplePayLineItem;
+  total?: string;
+
+  /**
+   * Display the recurring payment request on a monthly cadence
+   */
+  recurring?: boolean;
+
+  /**
+   * `options.pricing` line item descriptions to display in the Apple Pay payment sheet.
+   */
+  i18n?: I18n;
 
   /**
    * If provided, will override `options.total` and provide the current total price on the CheckoutPricing instance
@@ -39,7 +78,7 @@ export type ApplePayConfig = {
   form?: HTMLFormElement;
 
   /**
-   * If `options.requiredShippingContactFields` is present, validate that the browser supports the minimum version required for that option.
+   * If `requiredShippingContactFields` is specified, validate that the browser supports the minimum version required for that option.
    */
   enforceVersion?: boolean;
 
@@ -49,7 +88,12 @@ export type ApplePayConfig = {
   braintree?: {
     clientAuthorization: string;
   };
-} | ApplePayPaymentRequest;
+
+  /**
+   * The request for a payment.
+   */
+  paymentRequest?: ApplePayPaymentRequest;
+};
 
 export type ApplePayEvent =
   | 'token'

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -101,6 +101,40 @@ export type ApplePayLineItem = {
   recurringPaymentEndDate?: Date;
 };
 
+/**
+ * A dictionary that represents a request to set up a subscription.
+ */
+export type ApplePayRecurringPaymentRequest = {
+  /**
+   * A description of the recurring payment that Apple Pay displays to the user in the payment sheet.
+   */
+  paymentDescription: string;
+
+  /**
+   * The regular billing cycle for the recurring payment, including start and end dates, an interval, and an interval count.
+   */
+  regularBilling: ApplePayLineItem ;
+
+  /**
+   * The trial billing cycle for the recurring payment.
+   */
+  trialBilling?: ApplePayLineItem ;
+
+  /**
+   * A localized billing agreement that the payment sheet displays to the user before the user authorizes the payment.
+   */
+  billingAgreement?: string;
+
+  /**
+   * A URL to a web page where the user can update or delete the payment method for the recurring payment.
+   * Defaults to the managment URL set in the Recurly Apple Pay configuration.
+   */
+  managementURL?: string;
+};
+
+/**
+ * A request for payment, which includes information about payment-processing capabilities, the payment amount, and shipping information
+ */
 export type ApplePayPaymentRequest = {
   /**
    * Total cost to display in the Apple Pay payment sheet. Required if `options.pricing` is not provided.
@@ -132,4 +166,9 @@ export type ApplePayPaymentRequest = {
    * A set of line items that explain recurring payments and additional charges and discounts.
    */
   lineItems?: ApplePayLineItem[];
+
+  /**
+   * A property that requests a subscription.
+   */
+  recurringPaymentRequest?: ApplePayRecurringPaymentRequest;
 };


### PR DESCRIPTION
Cleans up the interface for calling into `recurly.ApplePay` so that the
properties that drift down to the resulting payment request are not
intermixed with the SDK specific parameters.

As a result, deprecates `options.requiredShippingContactFields` in favor
of reading it off of the `paymentRequest.requiredShippingContactFields`.

Adds `options.recurring` that, when provided in combination with
`options.total`, will create a total that will include a monthly
recurring charge on the payment sheet.

`options.paymentRequest` will be treated as the source of truth, except
for when `options.pricing` is provided. This maintains the stance that
Pricing controls the `total` and `lineItems`.

Can be will be generated if the `total` line item is set to `paymentTiming='recurring'`:
```typescript
const applePay = recurly.ApplePay({
  total: '29.00',
  recurring: true,
});
```

OR specified as the `recurringPaymentRequest` option:

```typescript
const total: ApplePayLineItem = {
  label: 'My Subscription',
  paymentTiming: 'recurring',
  amount: '29.00',
  recurringPaymentIntervalUnit: 'month',
  recurringPaymentIntervalCount: 1,
  recurringPaymentStartDate: new Date(),
};

const applePay = recurly.ApplePay({
  paymentRequest: {
    total,
    recurringPaymentRequest: {
      paymentDescription: 'A recurring subscription',
      regularBilling: total,
      billingAgreement: 'Will recur forever',
    }
  }
});
```