### PR TITLE
Update config type with requiredShippingContactFields

### DIFF
--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -86,13 +86,9 @@ export type ApplePayConfig = {
    * If set, the apple flow will require the user to provide these attributes.
    * See docs here: https://recurly.com/developers/reference/recurly-js/#apple-pay
    */
-  requiredShippingContactFields?: Array<(
-    | 'postalAddress'
-    | 'name'
-    | 'phoneticName'
-    | 'phone'
-    | 'email'
-  )>;
+  requiredShippingContactFields?: Array<
+      'postalAddress' | 'name' | 'phoneticName' | 'phone' | 'email'
+  >;
 
   /**
    * If provided, will use Braintree to process the ApplePay transaction.

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -42,6 +42,18 @@ export type ApplePayConfig = {
    * If `options.requiredShippingContactFields` is present, validate that the browser supports the minimum version required for that option.
    */
   enforceVersion?: boolean;
+  
+  /**
+   * If set, the apple flow will require the user to provide these attributes.
+   * See docs here: https://recurly.com/developers/reference/recurly-js/#apple-pay
+   */
+  requiredShippingContactFields?: (
+    | 'postalAddress'
+    | 'name'
+    | 'phoneticName'
+    | 'phone'
+    | 'email'
+  )[];
 
   /**
    * If provided, will use Braintree to process the ApplePay transaction.

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -42,18 +42,18 @@ export type ApplePayConfig = {
    * If `options.requiredShippingContactFields` is present, validate that the browser supports the minimum version required for that option.
    */
   enforceVersion?: boolean;
-  
+
   /**
    * If set, the apple flow will require the user to provide these attributes.
    * See docs here: https://recurly.com/developers/reference/recurly-js/#apple-pay
    */
-  requiredShippingContactFields?: (
+  requiredShippingContactFields?: Array<(
     | 'postalAddress'
     | 'name'
     | 'phoneticName'
     | 'phone'
     | 'email'
-  )[];
+  )>;
 
   /**
    * If provided, will use Braintree to process the ApplePay transaction.


### PR DESCRIPTION
Recurly.js now accepts the `requiredShippingContactFields` option: https://recurly.com/developers/reference/recurly-js/#apple-pay but attempting to set this option in a typescript setup will result in a TS error.