### PR TITLE
feat(Apple Pay): allow for customization of event updates

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -21,6 +21,17 @@ const I18N = {
   giftCardLineItemLabel: 'Gift card'
 };
 
+const CALLBACK_EVENT_MAP = {
+  onPaymentMethodSelected: 'paymentMethodSelected',
+  onShippingContactSelected: 'shippingContactSelected',
+  onShippingMethodSelected: 'shippingMethodSelected',
+  onPaymentAuthorized: 'paymentAuthorized'
+};
+
+const UPDATE_PROPERTIES = [
+  'newTotal', 'newLineItems', 'newRecurringPaymentRequest',
+];
+
 /**
  * Initializes an Apple Pay session.
  * Accepts all members of ApplePayPaymentRequest with the same name.
@@ -71,14 +82,23 @@ export class ApplePay extends Emitter {
     debug('Creating new Apple Pay session', paymentRequest);
 
     const session = new window.ApplePaySession(MINIMUM_SUPPORTED_VERSION, paymentRequest);
-    session.onvalidatemerchant = this.onValidateMerchant.bind(this);
-    session.onshippingcontactselected = this.onShippingContactSelected.bind(this);
-    session.onshippingmethodselected = this.onShippingMethodSelected.bind(this);
-    session.onpaymentmethodselected = this.onPaymentMethodSelected.bind(this);
-    session.onpaymentauthorized = this.onPaymentAuthorized.bind(this);
     session.oncancel = this.onCancel.bind(this);
+    session.onvalidatemerchant = this.onValidateMerchant.bind(this);
+    session.onpaymentmethodselected = makeCallback(this, 'onPaymentMethodSelected');
+    session.onshippingcontactselected = makeCallback(this, 'onShippingContactSelected');
+    session.onshippingmethodselected = makeCallback(this, 'onShippingMethodSelected');
+    session.onpaymentauthorized = this.token.bind(this);
 
-    return this._session = session;
+    return this.session = session;
+  }
+
+  /**
+   * Resets the session
+   * @private
+   */
+  set session (session) {
+    UPDATE_PROPERTIES.forEach(p => delete this[p]);
+    this._session = session;
   }
 
   /**
@@ -86,7 +106,7 @@ export class ApplePay extends Emitter {
    * @private
    */
   get recurringPaymentRequest () {
-    return this._paymentRequest?.recurringPaymentRequest;
+    return this.newRecurringPaymentRequest ?? this._paymentRequest?.recurringPaymentRequest;
   }
 
   /**
@@ -94,8 +114,7 @@ export class ApplePay extends Emitter {
    * @private
    */
   get lineItems () {
-    // Clone configured line items
-    return this._paymentRequest?.lineItems ? [].concat(this._paymentRequest.lineItems) : [];
+    return this.newLineItems ?? this._paymentRequest?.lineItems ?? [];
   }
 
   /**
@@ -103,7 +122,7 @@ export class ApplePay extends Emitter {
    * @private
    */
   get totalLineItem () {
-    return this._paymentRequest?.total ? this._paymentRequest.total : {};
+    return this.newTotal ?? this._paymentRequest?.total ?? {};
   }
 
   /**
@@ -136,8 +155,9 @@ export class ApplePay extends Emitter {
     if (options.recurly) this.recurly = options.recurly;
     else return this.initError = this.error('apple-pay-factory-only');
 
+    if (options.callbacks) this.config.callbacks = options.callbacks;
     if (options.form) this.config.form = options.form;
-    if (options.recurring) this.config.recurring = options.recurring;
+    if ('recurring' in options) this.config.recurring = options.recurring;
 
     this.config.i18n = {
       ...I18N,
@@ -221,7 +241,7 @@ export class ApplePay extends Emitter {
    * @private
    */
   onValidateMerchant (event) {
-    debug('Validating Apple Pay merchant session', event);
+    debug('validateMerchant', event);
 
     const validationURL = event.validationURL;
 
@@ -235,6 +255,14 @@ export class ApplePay extends Emitter {
     });
   }
 
+  /**
+   * sets the `contact` to the proper address on the pricing object.
+   *
+   * @param {string} addressType 'shippingAddress' or 'address'
+   * @param {object} contact The Apple Pay contact
+   * @param {Function} done
+   * @private
+   */
   setAddress (addressType, contact, done) {
     if (!contact || !this.config.pricing) return done?.();
 
@@ -244,22 +272,31 @@ export class ApplePay extends Emitter {
   }
 
   /**
+   * Stores the updates if any and completes the Apple Pay selection
+   * @param {Function} onComplete the session completion function
+   * @param {object} [update] the Apple Pay update object
+   * @private
+   */
+  completeSelection (onComplete, update) {
+    UPDATE_PROPERTIES.forEach(p => this[p] = update?.[p] ?? this[p]);
+
+    onComplete.call(this.session, {
+      newTotal: this.finalTotalLineItem,
+      newLineItems: this.lineItems,
+      newRecurringPaymentRequest: this.recurringPaymentRequest,
+      ...update,
+    });
+  }
+
+  /**
    * Handles payment method selection
    *
    * @param  {Event} event
    * @private
    */
-  onPaymentMethodSelected (event) {
-    debug('Payment method selected', event);
-
-    this.emit('paymentMethodSelected', event);
-
-    this.setAddress('address', event.paymentMethod.billingContact, () => {
-      this.session.completePaymentMethodSelection({
-        newTotal: this.finalTotalLineItem,
-        newLineItems: this.lineItems,
-        ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
-      });
+  onPaymentMethodSelected ({ paymentMethod: { billingContact } }, update) {
+    this.setAddress('address', billingContact, () => {
+      this.completeSelection(this.session.completePaymentMethodSelection, update);
     });
   }
 
@@ -269,16 +306,9 @@ export class ApplePay extends Emitter {
    * @param  {Event} event
    * @private
    */
-  onShippingContactSelected (event) {
-    this.emit('shippingContactSelected', event);
-
-    this.setAddress('shippingAddress', event.shippingContact, () => {
-      this.session.completeShippingContactSelection({
-        newTotal: this.finalTotalLineItem,
-        newLineItems: this.lineItems,
-        newShippingMethods: [],
-        ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
-      });
+  onShippingContactSelected ({ shippingContact }, update) {
+    this.setAddress('shippingAddress', shippingContact, () => {
+      this.completeSelection(this.session.completeShippingContactSelection, update);
     });
   }
 
@@ -288,15 +318,8 @@ export class ApplePay extends Emitter {
    * @param  {Event} event
    * @private
    */
-  onShippingMethodSelected (event) {
-    this.emit('shippingMethodSelected', event);
-
-    this.session.completeShippingMethodSelection({
-      newTotal: this.finalTotalLineItem,
-      newLineItems: this.lineItems,
-      newShippingMethods: [],
-      ...(this.recurringPaymentRequest && { newRecurringPaymentRequest: this.recurringPaymentRequest }),
-    });
+  onShippingMethodSelected (event, update) {
+    this.completeSelection(this.session.completeShippingMethodSelection, update);
   }
 
   /**
@@ -307,12 +330,15 @@ export class ApplePay extends Emitter {
    * @emit 'token'
    * @private
    */
-  onPaymentAuthorized (event) {
-    debug('Payment authorization received', event);
+  onPaymentAuthorized (event, { errors } = {}) {
+    if (typeof errors === 'object' && errors.length > 0) {
+      this.session.completePayment({ status: this.session.STATUS_FAILURE, errors });
+      return;
+    }
 
-    this.emit('paymentAuthorized', event);
-
-    return this.token(event);
+    this.session.completePayment({ status: this.session.STATUS_SUCCESS });
+    this.emit('authorized', event); // deprecated
+    this.emit('token', event.payment.recurlyToken, event);
   }
 
   token (event) {
@@ -329,9 +355,8 @@ export class ApplePay extends Emitter {
 
         debug('Token received', token);
 
-        this.session.completePayment({ status: this.session.STATUS_SUCCESS });
-        this.emit('authorized', event);
-        this.emit('token', token);
+        event.payment.recurlyToken = token;
+        makeCallback(this, 'onPaymentAuthorized')(event);
       }
     });
   }
@@ -380,6 +405,28 @@ export class ApplePay extends Emitter {
       ...(this.config.form && normalize(this.config.form, NON_ADDRESS_FIELDS, { parseCard: false }).values),
       ...transformAddress(billingContact, { to: 'address', except: ['emailAddress'] }),
     };
+  }
+}
+
+function makeCallback (applePay, callbackName) {
+  const callback = applePay.config.callbacks?.[callbackName];
+  const eventName = CALLBACK_EVENT_MAP[callbackName];
+  const handler = applePay[callbackName].bind(applePay);
+
+  return function (event) {
+    debug(eventName, event);
+    applePay.emit(eventName, event);
+    runCallback(callback, event, handler);
+  };
+}
+
+function runCallback (callback, event, done) {
+  const retVal = callback?.(event);
+
+  if (typeof retVal?.finally === 'function') {
+    retVal.finally(val => done(event, val));
+  } else {
+    done(event, retVal);
   }
 }
 

--- a/test/types/apple-pay.ts
+++ b/test/types/apple-pay.ts
@@ -1,4 +1,15 @@
-import { ApplePayPaymentRequest, ApplePayLineItem } from 'lib/apple-pay/native';
+import {
+  ApplePayPaymentRequest,
+  ApplePayLineItem,
+  ApplePayPaymentContact,
+  ApplePaySelectionUpdate,
+} from 'lib/apple-pay/native';
+
+function getTaxes(billingContact: ApplePayPaymentContact | undefined): ApplePaySelectionUpdate | void {
+  if (billingContact?.postalCode === '12345') {
+    return { newLineItems: [{ label: 'Tax', amount: '1.00' }] };
+  }
+}
 
 export default function applePay() {
   const applePaySimple = recurly.ApplePay({
@@ -45,6 +56,9 @@ export default function applePay() {
   const applePay = recurly.ApplePay({
     country: 'US',
     currency: 'USD',
+    callbacks: {
+      onPaymentMethodSelected: ({ paymentMethod: { billingContact } }) => getTaxes(billingContact),
+    },
     paymentRequest,
   });
 

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -1,6 +1,16 @@
 import { Emitter } from '../emitter';
 import { CheckoutPricingInstance, CheckoutPricingPromise } from '../pricing/checkout';
-import { ApplePayPaymentRequest } from './native';
+import { TokenPayload } from '../token';
+import {
+  ApplePayPaymentRequest,
+  ApplePayContactField,
+  ApplePaySelectionUpdate,
+  ApplePayErrorUpdate,
+  ApplePayPaymentSelectedEvent,
+  ApplePayShippingContactSelectedEvent,
+  ApplePayShippingMethodSelectedEvent,
+  ApplePayPaymentAuthorizedEvent,
+} from './native';
 
 export type I18n = {
   /**
@@ -28,6 +38,11 @@ export type I18n = {
    */
   giftCardLineItemLabel: string;
 };
+
+export type PaymentAuthorizedEvent = {
+  gatewayToken?: string;
+  recurlyToken: TokenPayload;
+} | ApplePayPaymentAuthorizedEvent;
 
 export type ApplePayConfig = {
   /**
@@ -63,6 +78,16 @@ export type ApplePayConfig = {
   i18n?: I18n;
 
   /**
+   * Callbacks for the events emitted by the payment session when a user selects options in the payment sheet.
+   */
+  callbacks?: {
+    onPaymentMethodSelected?: (event: ApplePayPaymentSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
+    onShippingContactSelected?: (event: ApplePayShippingContactSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
+    onShippingMethodSelected?: (event: ApplePayShippingMethodSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
+    onPaymentAuthorized?: (event: PaymentAuthorizedEvent) => Promise<ApplePayErrorUpdate> | ApplePayErrorUpdate | void,
+  };
+
+  /**
    * If provided, will override `options.total` and provide the current total price on the CheckoutPricing instance
    * when the Apple Pay flow is initiated.
    */
@@ -85,10 +110,9 @@ export type ApplePayConfig = {
   /**
    * If set, the apple flow will require the user to provide these attributes.
    * See docs here: https://recurly.com/developers/reference/recurly-js/#apple-pay
+   * @deprecated use paymentRequest.requiredShippingContactFields field instead
    */
-  requiredShippingContactFields?: Array<
-      'postalAddress' | 'name' | 'phoneticName' | 'phone' | 'email'
-  >;
+  requiredShippingContactFields?: ApplePayContactField[];
 
   /**
    * If provided, will use Braintree to process the ApplePay transaction.

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -23,6 +23,48 @@ export type ApplePayContactField =
   | 'phoneticName';
 
 /**
+ * The error code that indicates whether an error on the payment sheet is for shipping or billing information, or for another kind of error.
+ */
+export type ApplePayErrorCode =
+  /**
+   * Indicates that the shipping address or contact information is invalid or missing.
+   * Use with contactField
+   */
+  | "shippingContactInvalid"
+  /**
+   * Indicates that the billing address information is invalid or missing.
+   * Use with contactField
+   */
+  | "billingContactInvalid"
+  /**
+   * Indicates that the merchant can’t provide service to the shipping address (for example, can’t deliver to a P.O. Box).
+   */
+  | "addressUnserviceable"
+  /**
+   * Indicates an unknown but nonfatal error occurred during payment processing. The user can attempt authorization again.
+   */
+  | "unknown";
+
+/**
+ * Names of the fields in the shipping or billing contact information, used to locate errors in the payment sheet.
+ * @see {@link https://developer.apple.com/documentation/apple_pay_on_the_web/applepayerrorcontactfield} for when to use the fields.
+ */
+export type ApplePayErrorContactField =
+  | 'phoneNumber'
+  | 'emailAddress'
+  | 'name'
+  | 'phoneticName'
+  | 'postalAddress'
+  | 'addressLines'
+  | 'locality'
+  | 'subLocality'
+  | 'postalCode'
+  | 'administrativeArea'
+  | 'subAdministrativeArea'
+  | 'country'
+  | 'countryCode';
+
+/**
  * Contact information fields to use for billing and shipping contact information.
  */
 export type ApplePayPaymentContact = {
@@ -171,4 +213,146 @@ export type ApplePayPaymentRequest = {
    * A property that requests a subscription.
    */
   recurringPaymentRequest?: ApplePayRecurringPaymentRequest;
+};
+
+export class ApplePayError {
+  /**
+   * A customizable error type that you create to indicate problems with the address or contact information on an Apple Pay sheet.
+   * @param errorCode The error code for this instance.
+   * @param contactField The field name that contains the error on the payment sheet.
+   * @param message A localized, user-facing string that describes the error.
+   */
+  constructor(errorCode: ApplePayErrorCode, contactField?: ApplePayErrorContactField, message?: string);
+
+  /**
+   * The error code for this instance.
+   */
+  code: ApplePayErrorCode;
+
+  /**
+   * The field name that contains the error on the payment sheet.
+   */
+  contactField?: ApplePayErrorContactField;
+
+  /**
+   * A localized, user-facing string that describes the error.
+   */
+  message: string;
+}
+
+export type ApplePayErrorUpdate = {
+  /**
+   * A list of customized errors you provide that results from the user's selection.
+   */
+  errors?: ApplePayError[];
+};
+
+/**
+ * Updated transaction details to provide after the user's selection.
+ */
+export type ApplePaySelectionUpdate = {
+  /**
+   * The new total that results from the user's selection.
+   */
+  newTotal?: ApplePayLineItem;
+
+  /**
+   * Updated line items for the payment request that results from the user’s selection.
+   */
+  newLineItems?: ApplePayLineItem[];
+
+  /**
+   * The updated list of available shipping methods that results from the user's selection;
+   */
+  newRecurringPaymentRequest?: ApplePayRecurringPaymentRequest;
+} | ApplePayErrorUpdate;
+
+/**
+ * Describes an Apple Pay payment method
+ */
+export type ApplePayPaymentMethod = {
+  /**
+   * A string, suitable for display, that describes the card.
+   */
+  displayName?: string;
+
+  /**
+   * A string, suitable for display, that is the name of the payment network backing the card.
+   */
+  network?: string;
+
+  /**
+   * A string value representing the card's type of payment.
+   */
+  type?: (
+    | 'credit'
+    | 'debit'
+  );
+
+  /**
+   * The billing contact associated with the card.
+   */
+  billingContact?: ApplePayPaymentContact;
+};
+
+/**
+ * An event object that contains the payment method.
+ */
+export type ApplePayPaymentSelectedEvent = {
+  /**
+   * The card used to complete a payment.
+   */
+  paymentMethod: ApplePayPaymentMethod;
+};
+
+/**
+ * An event object that contains the shipping address the user selects.
+ */
+export type ApplePayShippingContactSelectedEvent = {
+  /**
+   * The shipping address selected by the user.
+   */
+  shippingContact: ApplePayPaymentContact;
+};
+
+/**
+ * An event object that contains the shipping method.
+ */
+export type ApplePayShippingMethodSelectedEvent = {
+  /**
+   * The shipping method selected by the user.
+   */
+  shippingMethod: any;
+};
+
+/**
+ * The result of authorizing a payment request that contains payment information.
+ */
+export type ApplePayPayment = {
+  token: {
+    /**
+     * Information about the card used in the transaction.
+     */
+    paymentMethod: ApplePayPaymentMethod,
+  };
+
+  /**
+   * The billing contact selected by the user for this transaction.
+   */
+  billingContact: ApplePayPaymentContact;
+
+  /**
+   * The shipping contact selected by the user for this transaction.
+   */
+  shippingContact: ApplePayPaymentContact;
+};
+
+/**
+ * An event object that contains the token used to authorize a payment.
+ */
+export type ApplePayPaymentAuthorizedEvent = {
+  /**
+   * The authorized payment information for this transaction.
+   */
+  payment: ApplePayPayment;
 };


### PR DESCRIPTION
Adds the `options.callbacks` option which supports the following
callbacks:
- `onPaymentMethodSelected`
- `onShippingContactSelected`
- `onShippingMethodSelected`
- `onPaymentAuthorized`
to correspond with the `ApplePaySession` events.

A callback must return either the Apple Pay update object or a Promise
that resolves with that object.

That update object will be used to complete the `ApplePaySession` event
to open up the ability to fetch custom taxes on payment method selection,
update shipping costs on shipping contact/method selection and validate
email/phone addresses on authorization.

This does not remove the existing events being emitted but the workflow
should be updated to prefer using `onPaymentAuthorized` to complete the
purchase instead of async on the `token` event. The event that is sent
to that callback includes the `payment.recurlyToken` for use.

This also enhances the `token` event to include the raw payment event as
the second argument.

```javascript
const applePay = recurly.ApplePay({ 
  ..., 
  paymentRequest: { requiredShippingContactFields: ['email'] },
  callbacks: {
    onPaymentAuthorized: ({ payment: { recurlyToken, shippingContact: { emailAddress } } }) => {
      if (emailAddress === "test@example.com") return { errors: [new window.ApplePayError(...)] };
    },
  },
});
```

This also enhances the `token` event to include the raw payment event as the second argument.