### PR TITLE
fix(apple pay): Do not teardown Braintree on cancel

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.braintree.js
+++ b/lib/recurly/apple-pay/apple-pay.braintree.js
@@ -68,7 +68,10 @@ export class ApplePayBraintree extends ApplePay {
         event.payment.gatewayToken = braintreeToken;
         return super.token(event);
       })
-      .catch(err => this.error('apple-pay-payment-failure', err));
+      .catch(err => {
+        this.session.completePayment({ status: this.session.STATUS_FAILURE });
+        return this.error('apple-pay-payment-failure', err);
+      });
   }
 
   mapPaymentData (event) {
@@ -80,13 +83,5 @@ export class ApplePayBraintree extends ApplePay {
         applePayPayment: super.mapPaymentData(event),
       },
     };
-  }
-
-  onCancel (event) {
-    debug('Teardown payment', event);
-
-    this.braintree.applePay
-      .teardown()
-      .finally(() => super.onCancel(event));
   }
 }

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -73,7 +73,6 @@ const getBraintreeStub = () => ({
     create: sinon.stub().resolves({
       performValidation: sinon.stub().resolves('MERCHANT_SESSION'),
       tokenize: sinon.stub().resolves('TOKENIZED_PAYLOAD'),
-      teardown: sinon.stub().resolves('TEARDOWN'),
     }),
   },
 });
@@ -1309,15 +1308,6 @@ function applePayTest (integrationType, requestMethod) {
             });
           });
         });
-
-        if (isBraintreeIntegration) {
-          it('teardown braintree', function (done) {
-            this.applePay.on('cancel', ensureDone(done, () => {
-              assert.ok(this.applePay.braintree.applePay.teardown.called);
-            }));
-            this.applePay.session.oncancel('event');
-          });
-        }
       });
     });
   });


### PR DESCRIPTION
`teardown` completely removes the Braintree instance which will cause issues if the client cancels and tries to initialize a payment. This is not needed as beginning a session does not reinitialize the BT client, so we can have successive attempts on the same client.

Fixes the `performValidation cannot be called after teardown` error on subsequent tries.