### PR TITLE
fix(apple pay): callbacks with promises resolve correctly

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -424,8 +424,8 @@ function makeCallback (applePay, callbackName) {
 function runCallback (callback, event, done) {
   const retVal = callback?.(event);
 
-  if (typeof retVal?.finally === 'function') {
-    retVal.finally(val => done(event, val));
+  if (typeof retVal?.then === 'function') {
+    retVal.catch(errors => ({ errors })).then(val => done(event, val));
   } else {
     done(event, retVal);
   }


### PR DESCRIPTION
When a callback returns a promise, R.js was using `finally` to update the payment sheet, however `finally` does not accept any arguments so no updates were actually propagated through to the payment sheet. This fixes that by using a `catch.then` to ensure that the promise is handled value is propagated correctly.