### PR TITLE
fix(apple pay): simplify newRecurringPaymentRequest handling

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -278,6 +278,10 @@ export class ApplePay extends Emitter {
    * @private
    */
   completeSelection (onComplete, { errors, ...update } = {}) {
+    if (update?.total && !update.newTotal) {
+      update.newTotal = { ...this.totalLineItem, amount: update.total };
+    }
+
     if (update?.newRecurringPaymentRequest) {
       // Ensure that the newRecurringPaymentRequest has the required properties
       // from the recurringPaymentRequest stored from initialization.

--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -40,10 +40,11 @@ const UPDATE_PROPERTIES = [
  * @param {Recurly} options.recurly
  * @param {String} options.country
  * @param {String} options.currency
- * @param {String|Object} [options.total] total for the payment in dollar format, eg: '1.00'. Optional and discarded if 'pricing' is supplied
+ * @param {String} [options.total] total for the payment in dollar format, eg: '1.00'. Optional and discarded if 'pricing' is supplied
  * @param {String} [options.label] The short, localized description of the total charge. Deprecated, use 'i18n.totalLineItemLabel'
  * @param {Boolean} [options.recurring] whether or not the total line item is recurring
  * @param {Object} [options.paymentRequest] an ApplePayPaymentRequest
+ * @param {Object} [options.callbacks] callbacks for ApplePay selection events
  * @param {HTMLElement} [options.form] to provide additional customer data
  * @param {Pricing} [options.pricing] to provide line items and total from Pricing
  * @param {Boolean} [options.enforceVersion] to ensure that the client supports the minimum version to support required fields

--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -278,6 +278,23 @@ export class ApplePay extends Emitter {
    * @private
    */
   completeSelection (onComplete, { errors, ...update } = {}) {
+    if (update?.newRecurringPaymentRequest) {
+      // Ensure that the newRecurringPaymentRequest has the required properties
+      // from the recurringPaymentRequest stored from initialization.
+      update.newRecurringPaymentRequest = {
+        managementURL: this.recurringPaymentRequest?.managementURL,
+        paymentDescription: this.recurringPaymentRequest?.paymentDescription,
+        ...update.newRecurringPaymentRequest,
+      };
+    } else if (this.recurringPaymentRequest && update?.newTotal?.paymentTiming === 'recurring') {
+      // Ensure the recurringPaymentRequest is updated with the new total
+      // if not provided.
+      update.newRecurringPaymentRequest = {
+        ...this.recurringPaymentRequest,
+        regularBilling: update.newTotal,
+      };
+    }
+
     UPDATE_PROPERTIES.forEach(p => this[p] = update?.[p] ?? this[p]);
 
     onComplete.call(this.session, {
@@ -350,6 +367,7 @@ export class ApplePay extends Emitter {
       data,
       done: (err, token) => {
         if (err) {
+          debug('tokenization error', err);
           this.session.completePayment({ status: this.session.STATUS_FAILURE });
           return this.error('apple-pay-payment-failure', err);
         }

--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -6,8 +6,6 @@ import { lineItem } from './apple-pay-line-item';
 const REQUIRED_SHIPPING_FIELDS_VERSION = 6;
 
 function buildOrder (config, options, paymentRequest) {
-  if (!paymentRequest.total && !options.total) return errors('apple-pay-config-missing', { opt: 'total' });
-
   let { total: totalLineItem } = paymentRequest;
   if (!totalLineItem) {
     const { recurring, total } = options;

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -76,15 +76,7 @@ export class BraintreeStrategy extends VenmoStrategy {
   }
 
   handleVenmoError (err) {
-    if (err.code === 'VENMO_CANCELED') {
-      console.log('App is not available or user aborted payment flow');
-    } else if (err.code === 'VENMO_APP_CANCELED') {
-      if (err.code === 'VENMO_POPUP_CLOSED')
-        console.log('User canceled payment flow');
-    } else {
-      console.error('An error occurred:', err.message);
-    }
-
+    debug('Venmo error', err);
     this.emit('cancel');
     return this.error('venmo-braintree-tokenize-braintree-error', { cause: err });
   }

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -208,14 +208,11 @@ function applePayTest (integrationType, requestMethod) {
       });
 
       describe('when not given options.pricing', function () {
-        it('requires options.total', function (done) {
+        it('uses a $0 total when options.total is not provided', function (done) {
           let applePay = this.recurly.ApplePay(omit(validOpts, 'total'));
-          applePay.on('error', function (err) {
-            nextTick(ensureDone(done, () => {
-              assert.equal(err, applePay.initError);
-              assertInitError(applePay, 'apple-pay-config-missing', { opt: 'total' });
-            }));
-          });
+          applePay.ready(ensureDone(done, () => {
+            assert.equal(applePay.session.total.amount, '0.00');
+          }));
         });
 
         it('creates the total line item from options.total and the default options.label if absent', function (done) {

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -907,6 +907,16 @@ function applePayTest (integrationType, requestMethod) {
           this.applePay.session.onpaymentmethodselected({ paymentMethod: {} });
         });
 
+        it('accepts the total and sets the newTotal', function (done) {
+          this.applePay.config.callbacks = { onPaymentMethodSelected: () => Promise.resolve({ total: '100' }) };
+
+          this.applePay.session.on('completePaymentMethodSelection', ensureDone(done, (update) => {
+            assert.deepEqual(update.newTotal, this.applePay.totalLineItem);
+            assert.equal(this.applePay.finalTotalLineItem.amount, '100');
+          }));
+          this.applePay.session.onpaymentmethodselected({ paymentMethod: {} });
+        });
+
         describe('with options.recurringPaymentRequest set', function () {
           beforeEach(function (done) {
             this.applePay = this.recurly.ApplePay(merge({}, validOpts, { recurring: true }));
@@ -948,6 +958,17 @@ function applePayTest (integrationType, requestMethod) {
               assert.equal(update.newRecurringPaymentRequest.regularBilling.amount, '100');
             }));
             this.applePay.session.onpaymentmethodselected({ paymentMethod: { billingContact: { postalCode: '94114' } } });
+          });
+
+          it('sets the newRecurringPaymentRequest amount from the total', function (done) {
+            this.applePay.config.callbacks = { onPaymentMethodSelected: () => Promise.resolve({ total: '100' }) };
+
+            this.applePay.session.on('completePaymentMethodSelection', ensureDone(done, (update) => {
+              assert.deepEqual(update.newTotal, this.applePay.totalLineItem);
+              assert.equal(this.applePay.finalTotalLineItem.amount, '100');
+              assert.equal(this.applePay.recurringPaymentRequest.regularBilling.amount, '100');
+            }));
+            this.applePay.session.onpaymentmethodselected({ paymentMethod: {} });
           });
         });
 

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -58,8 +58,7 @@ export type ApplePayConfig = {
   label?: string;
 
   /**
-   * Total cost to display in the Apple Pay payment sheet. Required if `options.pricing` or
-   * `options.paymentRequest.total` is not provided.
+   * Total cost to display in the Apple Pay payment sheet. Defaults to '0'.
    */
   total?: string;
 

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -249,6 +249,11 @@ export type ApplePayErrorUpdate = {
  */
 export type ApplePaySelectionUpdate = {
   /**
+   * The new total cost that results from the user's selection.
+   */
+  total?: string;
+
+  /**
    * The new total that results from the user's selection.
    */
   newTotal?: ApplePayLineItem;


### PR DESCRIPTION
[simplify newRecurringPaymentRequest handling](https://github.com/recurly/recurly-js/pull/815/commits/7ab71ce96ca58b6a754373ab4e618bd7f0273165) 
There are a variety of methods to initialize ApplePay with various
levels of integration with the native ApplePay request. On the simplest
level of configuration (`total`, `recurring` options), the merchant
might want to register the `onPaymentMethodSelected` callback to update
the total. Since the library creates the `recurringPaymentRequest` for
them automatically, we need to keep that total up to date if it changes.

We also manage the managementURL, so that property can be omitted when using the callback and added in automatically by the library.

[allow total to be specified on update callback](https://github.com/recurly/recurly-js/pull/815/commits/b0d5ea264193aca4c4eb958ba4b13e1f698d91e3) 
To simplify the integration for users using `options.total` and
optionally, `options.recurring`, along with `options.callbacks` to
update the total, the user can just specify the new `total` in the
callback and the library will convert that to `newTotal` for them to
hide the native Apple Pay internals.

[Default options.total to $0](https://github.com/recurly/recurly-js/pull/815/commits/2ee9e6aef788cdbbccdd64611e96b067ef8cae02) 
In 4.22, if `options.total` was provided as undefined, it would default
to $0 if no pricing was provided. This restores that behavior and goes
one step further by removing the requirement of `options.total`
altogether.