### PR TITLE
Add ApplePay coupon code changed support

### DIFF
--- a/lib/recurly/apple-pay/apple-pay.js
+++ b/lib/recurly/apple-pay/apple-pay.js
@@ -18,14 +18,15 @@ const I18N = {
   totalLineItemLabel: 'Total',
   discountLineItemLabel: 'Discount',
   taxLineItemLabel: 'Tax',
-  giftCardLineItemLabel: 'Gift card'
+  giftCardLineItemLabel: 'Gift card',
 };
 
 const CALLBACK_EVENT_MAP = {
   onPaymentMethodSelected: 'paymentMethodSelected',
   onShippingContactSelected: 'shippingContactSelected',
   onShippingMethodSelected: 'shippingMethodSelected',
-  onPaymentAuthorized: 'paymentAuthorized'
+  onCouponCodeChanged: 'couponCodeChanged',
+  onPaymentAuthorized: 'paymentAuthorized',
 };
 
 const UPDATE_PROPERTIES = [
@@ -86,6 +87,7 @@ export class ApplePay extends Emitter {
     session.oncancel = this.onCancel.bind(this);
     session.onvalidatemerchant = this.onValidateMerchant.bind(this);
     session.onpaymentmethodselected = makeCallback(this, 'onPaymentMethodSelected');
+    session.oncouponcodechanged = makeCallback(this, 'onCouponCodeChanged');
     session.onshippingcontactselected = makeCallback(this, 'onShippingContactSelected');
     session.onshippingmethodselected = makeCallback(this, 'onShippingMethodSelected');
     session.onpaymentauthorized = this.token.bind(this);
@@ -309,6 +311,16 @@ export class ApplePay extends Emitter {
       ...((typeof errors === 'object' && errors.length > 0) && { errors: errors.map(makeApplePayError) }),
       ...update,
     });
+  }
+
+  /**
+    * Handles coupon code selection
+    *
+    * @param {Event} event
+    * @private
+    */
+  onCouponCodeChanged (event, update) {
+    this.completeSelection(this.session.completeCouponCodeChange, update);
   }
 
   /**

--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -95,6 +95,7 @@ function applyRemoteConfig (paymentRequest, cb) {
 
     const { recurringPaymentRequest } = paymentRequest;
     if (recurringPaymentRequest) {
+      recurringPaymentRequest.tokenNotificationURL = info.tokenNotificationURL;
       if (!recurringPaymentRequest.managementURL && !info.managementURL) {
         return cb(errors('apple-pay-config-invalid', { opt: 'recurringPaymentRequest.managementURL' }));
       } else if (!recurringPaymentRequest.managementURL) {

--- a/test/server/fixtures/apple_pay/info.json
+++ b/test/server/fixtures/apple_pay/info.json
@@ -4,5 +4,6 @@
   "currencies": ["USD", "CAD"],
   "merchantCapabilities": ["supportsCredit", "supports3DS", "supportsDebit"],
   "supportedNetworks": ["visa", "amex"],
-  "managementURL": "https://example.com/account"
+  "managementURL": "https://example.com/account",
+  "tokenNotificationURL": "https://recurly.com"
 }

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -8,6 +8,7 @@ import {
   ApplePayPaymentMethodSelectedEvent,
   ApplePayShippingContactSelectedEvent,
   ApplePayShippingMethodSelectedEvent,
+  ApplePayCouponCodeChangedEvent,
   ApplePayPaymentAuthorizedEvent,
 } from './native';
 
@@ -79,6 +80,7 @@ export type ApplePayConfig = {
     onPaymentMethodSelected?: (event: ApplePayPaymentMethodSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
     onShippingContactSelected?: (event: ApplePayShippingContactSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
     onShippingMethodSelected?: (event: ApplePayShippingMethodSelectedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
+    onCouponCodeChanged?: (event: ApplePayCouponCodeChangedEvent) => Promise<ApplePaySelectionUpdate> | ApplePaySelectionUpdate | void,
     onPaymentAuthorized?: (event: ApplePayPaymentAuthorizedEvent) => Promise<ApplePayErrorUpdate> | ApplePayErrorUpdate | void,
   };
 

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -328,6 +328,16 @@ export type ApplePayShippingMethodSelectedEvent = {
 };
 
 /**
+ * An event object that contains the coupon code.
+ */
+export type ApplePayCouponCodeChangedEvent = {
+  /**
+   * The coupon code selected by the user.
+   */
+  couponCode: string;
+};
+
+/**
  * The result of authorizing a payment request that contains payment information.
  */
 export type ApplePayPayment = {

--- a/types/lib/google-pay/native.d.ts
+++ b/types/lib/google-pay/native.d.ts
@@ -84,8 +84,8 @@ export type GooglePayTransactionInfo = {
   totalPrice?: string;
 
   /**
-   *  All of the available charges for the current payment request.
-   *  Required and only populated in the payment sheet if you use Authorize Payments or Dynamic Price Updates.
+   * All of the available charges for the current payment request.
+   * Required and only populated in the payment sheet if you use Authorize Payments or Dynamic Price Updates.
    */
   displayItems?: GooglePayDisplayItem[];
 
@@ -177,8 +177,8 @@ export type GooglePayShippingOptionParameters = {
   shippingOptions: GooglePaySelectionOption[];
 
   /**
-   * 	An identifier to the default selected shipping option.
-   * 	If this field isn't provided, the first option is the default option.
+   *  An identifier to the default selected shipping option.
+   *  If this field isn't provided, the first option is the default option.
    */
   defaultSelectedOptionId?: string;
 };
@@ -213,7 +213,7 @@ export type GooglePayPaymentDataRequest = {
   shippingAddressRequired?: boolean;
 
   /**
-   * 	If shippingAddressRequired is set to true, specify shipping address restrictions.
+   * If shippingAddressRequired is set to true, specify shipping address restrictions.
    */
   shippingAddressParameters?: GooglePayShippingAddressParameters;
 
@@ -266,7 +266,7 @@ export type GooglePayIntermediatePaymentData = {
 
   shippingOptionData?: {
     /**
-     * 	Matches with SelectionOption.id
+     * Matches with SelectionOption.id
      */
     id: string;
   };


### PR DESCRIPTION
Emits the `couponCodeChanged` event on the `recurly.ApplePay` instance and allows for `options.callbacks.onCouponCodeChanged` to receive the [`ApplePayCouponCodeChangedEvent `](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaycouponcodechangedevent) from Apple.

Note that this does not automatically hook into the `pricing.couponCode` entry as I could not get it to update the pricing in my testing, will follow up on that later but having base level support was requested.