### PR TITLE
Remove .only in tests that prevented other tests from running

### DIFF
--- a/test/unit/risk/three-d-secure/strategy/paypal-complete.test.js
+++ b/test/unit/risk/three-d-secure/strategy/paypal-complete.test.js
@@ -28,7 +28,7 @@ describe('PaypalCompleteStrategy', function () {
     this.sandbox.restore();
   });
 
-  describe.only('attach', function () {
+  describe('attach', function () {
     it('creates a frame and appends finish URL to the redirect URL', function () {
       const { strategy, target, recurly } = this;
       strategy.attach(target);


### PR DESCRIPTION
Remove `.only` in tests that prevented other tests from running