### PR TITLE
Renamed PayPalCommerce to PayPalComplete

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/paypal-complete.js
+++ b/lib/recurly/risk/three-d-secure/strategy/paypal-complete.js
@@ -4,7 +4,7 @@ import { Frame } from '../../../frame';
 const debug = require('debug')('recurly:risk:three-d-secure:paypalcomplete');
 
 export default class PayPalCompleteStrategy extends ThreeDSecureStrategy {
-  static strategyName = 'paypal_commerce';
+  static strategyName = 'paypal_complete';
 
   constructor (...args) {
     super(...args);

--- a/packages/public-api-fixture-server/fixtures/tokens/action-token-paypal-complete.json
+++ b/packages/public-api-fixture-server/fixtures/tokens/action-token-paypal-complete.json
@@ -9,7 +9,7 @@
     }
   },
   "gateway": {
-    "type": "paypal_commerce",
+    "type": "paypal_complete",
     "credentials": {}
   },
   "transaction": {


### PR DESCRIPTION
This PR renames PayPalCommerce to PaypalComplete