### PR TITLE
feat(apple pay): Improve support

### DIFF
--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -31,6 +31,7 @@ jobs:
           $(cat recurly-js/types/index.d.ts)" > recurly-js/types/index.d.ts
 
           rm recurly-js/test/types/tsconfig.json \
+             recurly-js/test/types/tslint.json \
              recurly-js/test/types/index.d.ts \
              recurly-js/types/tsconfig.json \
              recurly-js/types/tslint.json

--- a/lib/recurly/apple-pay/apple-pay.braintree.js
+++ b/lib/recurly/apple-pay/apple-pay.braintree.js
@@ -35,6 +35,8 @@ export class ApplePayBraintree extends ApplePay {
     debug('Initializing client');
 
     const authorization = options.braintree.clientAuthorization;
+    if (options.braintree.displayName) this.displayName = options.braintree.displayName;
+    else this.displayName = 'My Store';
 
     loadBraintree('applePay', 'dataCollector')
       .then(() => window.braintree.client.create({ authorization }))
@@ -54,7 +56,7 @@ export class ApplePayBraintree extends ApplePay {
     debug('Validating merchant session', event);
 
     this.braintree.applePay
-      .performValidation({ validationURL: event.validationURL, displayName: 'My Store' })
+      .performValidation({ validationURL: event.validationURL, displayName: this.displayName })
       .then(merchantSession => this.session.completeMerchantValidation(merchantSession))
       .catch(err => this.error(err));
   }

--- a/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
+++ b/lib/recurly/apple-pay/util/build-apple-pay-payment-request.js
@@ -40,11 +40,13 @@ export default function buildApplePayPaymentRequest (applePay, options, cb) {
     countryCode: options.country,
     requiredShippingContactFields: options.requiredShippingContactFields, // deprecated
     ...options.paymentRequest,
-    requiredBillingContactFields: ['postalAddress'],
   };
 
   if (!paymentRequest.currencyCode) return cb(errors('apple-pay-config-missing', { opt: 'currency' }));
   if (!paymentRequest.countryCode) return cb(errors('apple-pay-config-missing', { opt: 'country' }));
+  paymentRequest.requiredBillingContactFields = paymentRequest.requiredBillingContactFields
+    ? Array.from(new Set([...paymentRequest.requiredBillingContactFields, 'postalAddress']))
+    : ['postalAddress'];
 
   // The order is handled by pricing if set
   if (!config.pricing) {

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -849,13 +849,20 @@ function applePayTest (integrationType) {
           });
 
           it('calls the braintree performValidation with the validation url', function (done) {
-            this.applePay.session.on('completeMerchantValidation', ensureDone(done, () => {
-              assert.ok(this.applePay.braintree.applePay.performValidation.calledWith({
-                validationURL: 'valid-test-url',
-                displayName: 'My Store'
-              }));
+            const applePay = this.recurly.ApplePay(merge({}, validOpts, {
+              braintree: {
+                displayName: 'My Great Store',
+              }
             }));
-            this.applePay.session.onvalidatemerchant({ validationURL: 'valid-test-url' });
+            applePay.ready(ensureDone(done, () => {
+              applePay.session.on('completeMerchantValidation', ensureDone(done, () => {
+                assert.ok(applePay.braintree.applePay.performValidation.calledWith({
+                  validationURL: 'valid-test-url',
+                  displayName: 'My Great Store'
+                }));
+              }));
+              applePay.session.onvalidatemerchant({ validationURL: 'valid-test-url' });
+            }));
           });
 
           it('calls the completeMerchantValidation with the merchant session', function (done) {

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -495,6 +495,27 @@ function applePayTest (integrationType) {
         }));
       });
 
+      describe('requiredBillingContactFields', function () {
+        it('defaults to the postalAddress', function (done) {
+          const applePay = this.recurly.ApplePay(validOpts);
+          applePay.ready(ensureDone(done, () => {
+            assert.deepEqual(applePay.session.requiredBillingContactFields, ['postalAddress']);
+          }));
+        });
+
+        it('includes the configuration billing fields', function (done) {
+          const applePay = this.recurly.ApplePay(merge({} , validOpts, {
+            paymentRequest: {
+              requiredBillingContactFields: ['name', 'postalAddress'],
+            },
+          }));
+
+          applePay.ready(ensureDone(done, () => {
+            assert.deepEqual(applePay.session.requiredBillingContactFields, ['name', 'postalAddress']);
+          }));
+        });
+      });
+
       describe('merchant info collection', function () {
         beforeEach(function () {
           this.applePay = this.recurly.ApplePay(validOpts);

--- a/types/lib/apple-pay/index.d.ts
+++ b/types/lib/apple-pay/index.d.ts
@@ -116,6 +116,11 @@ export type ApplePayConfig = {
    */
   braintree?: {
     clientAuthorization: string;
+
+    /**
+     * Canonical name for your store, suitable for display.
+     */
+    displayName?: string;
   };
 
   /**

--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -202,6 +202,11 @@ export type ApplePayPaymentRequest = {
   requiredShippingContactFields?: ApplePayContactField[];
 
   /**
+   * The fields of billing information the user must provide to process the transaction. Defaults to `['postalAddress']`.
+   */
+  requiredBillingContactFields?: ApplePayContactField[];
+
+  /**
    * Shipping contact information for the user.
    */
   shippingContact?: ApplePayPaymentContact;


### PR DESCRIPTION
*  Support Merchant displayName for Braintree through `options.braintree.displayName`
*  Support requiredBillingContactFields overrides through `options.paymentRequest.requiredBillingContactFields`

