### PR TITLE
Update to latest version of Braintree JS Client

### DIFF
--- a/lib/recurly/paypal/strategy/braintree.js
+++ b/lib/recurly/paypal/strategy/braintree.js
@@ -4,7 +4,7 @@ import { PayPalStrategy } from './index';
 
 const debug = require('debug')('recurly:paypal:strategy:braintree');
 
-export const BRAINTREE_CLIENT_VERSION = '3.76.0';
+export const BRAINTREE_CLIENT_VERSION = '3.96.0';
 
 /**
  * Braintree-specific PayPal handler

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -3,7 +3,7 @@ import after from '../../../util/after';
 import { VenmoStrategy } from './index';
 import { normalize } from '../../../util/normalize';
 
-export const BRAINTREE_CLIENT_VERSION = '3.76.0';
+export const BRAINTREE_CLIENT_VERSION = '3.96.0';
 
 const debug = require('debug')('recurly:paypal:strategy:braintree');
 
@@ -85,7 +85,7 @@ export class BraintreeStrategy extends VenmoStrategy {
     const nameData = normalize(this.form, ['first_name', 'last_name']);
     this.recurly.request.post({
       route: '/venmo/token',
-      data: { type: 'braintree', payload: { ...payload, ...nameData } },
+      data: { type: 'braintree', payload: { ...payload, values: nameData.values } },
       done: (error, token) => {
         if (error) return this.error('venmo-braintree-tokenize-recurly-error', { cause: error });
         this.emit('token', token);


### PR DESCRIPTION
Update to latest version of Braintree JS Client from `3.76.0` to `3.96.0`