### PR TITLE
Prevent multiple 3ds instances

### DIFF
--- a/lib/recurly/errors.js
+++ b/lib/recurly/errors.js
@@ -309,7 +309,7 @@ const ERRORS = [
   },
   {
     code: '3ds-multiple-instances',
-    message: `More than one instance of 3DS was initialized. Make sure you remove the previous instance before
+    message: `More than one instance of threeDSecure was initialized. Make sure you remove the previous instance before
               initializing a new one.`,
     classification: 'merchant'
   },

--- a/lib/recurly/errors.js
+++ b/lib/recurly/errors.js
@@ -308,6 +308,12 @@ const ERRORS = [
     classification: 'internal'
   },
   {
+    code: '3ds-multiple-instances',
+    message: `More than one instance of 3DS was initialized. Make sure you remove the previous instance before
+              initializing a new one.`,
+    classification: 'merchant'
+  },
+  {
     code: '3ds-auth-error',
     message: `We were unable to authenticate your payment method. Please choose a different payment
               method and try again.`,

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -107,6 +107,11 @@ export class ThreeDSecure extends RiskConcern {
   }
 
   constructor ({ risk, actionTokenId, challengeWindowSize }) {
+    const existingConcern = risk.concerns.find((concern) => concern instanceof ThreeDSecure);
+    if (existingConcern) {
+      throw errors('3ds-multiple-instances', { name: 'ThreeDSecure', expect: 'to be the only concern' });
+    }
+
     super({ risk });
 
     this.actionTokenId = actionTokenId;

--- a/test/unit/risk/three-d-secure.test.js
+++ b/test/unit/risk/three-d-secure.test.js
@@ -145,7 +145,7 @@ describe('ThreeDSecure', function () {
 
       assert.throws(() => {
         new ThreeDSecure({ risk, actionTokenId });
-      }, /More than one instance of 3DS was initialized./);
+      }, /More than one instance of threeDSecure was initialized. Make sure you remove the previous instance before initializing a new one./);
       assert(risk.add.calledOnce);
     });
   });

--- a/test/unit/risk/three-d-secure.test.js
+++ b/test/unit/risk/three-d-secure.test.js
@@ -20,7 +20,7 @@ describe('ThreeDSecure', function () {
   beforeEach(function (done) {
     const actionTokenId = this.actionTokenId = 'action-token-test';
     const recurly = this.recurly = initRecurly();
-    const risk = this.risk = { add: sinon.stub(), remove: sinon.stub(), recurly };
+    const risk = this.risk = { add: sinon.stub(), remove: sinon.stub(),concerns: [], recurly };
     const sandbox = this.sandbox = sinon.createSandbox();
 
     // Neuter the third party lib loaders
@@ -51,7 +51,7 @@ describe('ThreeDSecure', function () {
   describe('factory', function () {
     beforeEach(function () {
       const { sandbox, recurly } = this;
-      this.riskStub = { add: sandbox.stub(), recurly };
+      this.riskStub = { add: sandbox.stub(), recurly, concerns: [] };
     });
 
     it('returns a ThreeDSecure instance', function () {
@@ -136,6 +136,18 @@ describe('ThreeDSecure', function () {
       'three-d-secure:create',
       { concernId: threeDSecure.id, actionTokenId }
     ));
+  });
+
+  describe('when a threeDSecure instance already exists', function () {
+    it('throws and errror and prevents another one from being added', function () {
+      const { risk, actionTokenId, threeDSecure } = this;
+      risk.concerns.push(threeDSecure);
+
+      assert.throws(() => {
+        new ThreeDSecure({ risk, actionTokenId });
+      }, /More than one instance of 3DS was initialized./);
+      assert(risk.add.calledOnce);
+    });
   });
 
   describe('recurly', function () {


### PR DESCRIPTION
When multiple purchases are attempted for the same customer/card within a similar timeframe, multiple 3DS challenges can occur which can cause issues with authorization on some gateways. This will prevent multiple challenges from existing and throw an error which indicates that another challenge already exists.