### PR TITLE
feat(google pay): Add support for `existingPaymentMethodRequired`

### DIFF
--- a/lib/recurly/google-pay/google-pay.js
+++ b/lib/recurly/google-pay/google-pay.js
@@ -126,7 +126,15 @@ const getGoogleInfoFromMerchantInfo = ({ recurlyMerchantInfo, options }) => {
     },
   };
 
-  return { gatewayCode, environment, isReadyToPayRequest, paymentDataRequest };
+  return {
+    gatewayCode,
+    environment,
+    isReadyToPayRequest: {
+      ...isReadyToPayRequest,
+      ...(options.existingPaymentMethodRequired === true && { existingPaymentMethodRequired: true }),
+    },
+    paymentDataRequest,
+  };
 };
 
 const buildPaymentDataRequest = ({ recurly, options }) => {

--- a/lib/recurly/google-pay/pay-with-google.js
+++ b/lib/recurly/google-pay/pay-with-google.js
@@ -77,8 +77,8 @@ const payWithGoogle = ({ paymentOptions, isReadyToPayRequest, paymentDataRequest
     .catch(err => {
       throw recurlyError('google-pay-init-error', { err });
     })
-    .then(({ result: isReadyToPay }) => {
-      if (!isReadyToPay) {
+    .then(({ result: isReadyToPay, paymentMethodPresent }) => {
+      if (!isReadyToPay || paymentMethodPresent === false) {
         throw recurlyError('google-pay-not-available');
       }
 

--- a/types/lib/google-pay/index.d.ts
+++ b/types/lib/google-pay/index.d.ts
@@ -59,6 +59,13 @@ export type GooglePayOptions = {
   };
 
   /**
+   * If set to true, then the Google Pay button will not be rendered and an error will be emitted if the user
+   * is not eligible to pay with Google Pay.
+   * See https://developers.google.com/pay/api/web/reference/request-objects#IsReadyToPayRequest for more information.
+   */
+  existingPaymentMethodRequired?: boolean;
+
+  /**
    * Requires the user to accept providing the full billing address.
    * @deprecated use billingAddressRequired
    */


### PR DESCRIPTION
Adds support for `IsReadyToPayRequest.existingPaymentMethodRequired` to emit a `google-pay-not-available` error and not render the button if the user does not have a card that is supported by merchant's gateway configuration.

This can be configured via the `existingPaymentMethodRequired` option in `recurly.GooglePay`.