### PR TITLE
Add error and close Events on AmazonPay V2

### DIFF
--- a/lib/recurly/amazon/amazon-pay.js
+++ b/lib/recurly/amazon/amazon-pay.js
@@ -17,10 +17,10 @@ class AmazonPay extends Emitter {
       path: `/amazon_pay/start?region=${this.region}`,
       type: Frame.TYPES.WINDOW,
       defaultEventName
-    }).on('error', cause => console.log(cause))
-      .on('done', results => {
-        this.emit('token', results);
-      });
+    })
+      .on('error', cause => this.emit('error', cause)) // Emitted by js/v1/amazon_pay/cancel
+      .on('close', () => this.emit('error', 'closed')) // Emitted by RJS Frame when the window is manually closed
+      .on('done', results => this.emit('token', results)); // Emitted by js/v1/amazon_pay/finish
   }
 }
 


### PR DESCRIPTION
Add support to `error` and `close` events on AmazonPay V2 instance. 

This allow clients to properly listen to them and take actions when a payment is cancelled, failed or the popup window is closed.