### PR TITLE
fix tax calculations on next object with single-use coupons

### DIFF
--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -149,10 +149,6 @@ export default class Calculations {
       this.price.next.discount = discountNext;
     }
 
-    // return promise.then(() => {
-    //   if (coupon.single_use) this.price.next.discount = 0;
-    // });
-
     return promise;
   }
 
@@ -331,6 +327,7 @@ export default class Calculations {
    *
    * @return {Object} { discountNow, discountNext }
    */
+
   discountAmounts () {
     const coupon = this.items.coupon;
     let discountNow = 0;
@@ -358,27 +355,6 @@ export default class Calculations {
     return { discountNow, discountNext };
   }
 
-  // discountAmounts () {
-  //   const coupon = this.items.coupon;
-  //   let discountNow = 0;
-  //   let discountNext = 0;
-  //   if (coupon) {
-  //     if (coupon.discount.type === 'free_trial') {
-  //       // Amounts are left zero
-  //     } else if (coupon.discount.rate) {
-  //       const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
-  //       discountNow = roundForDiscount(discountableNow * coupon.discount.rate);
-  //       discountNext = roundForDiscount(discountableNext * coupon.discount.rate);
-  //     } else if (coupon.discount.amount) {
-  //       const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
-  //       // Falls back to zero if the coupon does not support the checkout currency
-  //       const discountAmount = coupon.discount.amount[this.items.currency] || 0;
-  //       discountNow = Math.min(discountableNow, discountAmount);
-  //       discountNext = Math.min(discountableNext, discountAmount);
-  //     }
-  //   }
-  //   return { discountNow, discountNext };
-  // }
   /**
    * Computes the discountable subtotals for a given coupon
    *

--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -149,9 +149,11 @@ export default class Calculations {
       this.price.next.discount = discountNext;
     }
 
-    return promise.then(() => {
-      if (coupon.single_use) this.price.next.discount = 0;
-    });
+    // return promise.then(() => {
+    //   if (coupon.single_use) this.price.next.discount = 0;
+    // });
+
+    return promise;
   }
 
   /**
@@ -339,18 +341,44 @@ export default class Calculations {
       } else if (coupon.discount.rate) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
         discountNow = roundForDiscount(discountableNow * coupon.discount.rate);
-        discountNext = roundForDiscount(discountableNext * coupon.discount.rate);
+        // If coupon is single use, we want discountNext to be zero
+        if (!coupon.single_use) {
+          discountNext = roundForDiscount(discountableNext * coupon.discount.rate);
+        }
       } else if (coupon.discount.amount) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
         // Falls back to zero if the coupon does not support the checkout currency
         const discountAmount = coupon.discount.amount[this.items.currency] || 0;
         discountNow = Math.min(discountableNow, discountAmount);
-        discountNext = Math.min(discountableNext, discountAmount);
+        if (!coupon.single_use) {
+          discountNext = Math.min(discountableNext, discountAmount);
+        }
       }
     }
     return { discountNow, discountNext };
   }
 
+  // discountAmounts () {
+  //   const coupon = this.items.coupon;
+  //   let discountNow = 0;
+  //   let discountNext = 0;
+  //   if (coupon) {
+  //     if (coupon.discount.type === 'free_trial') {
+  //       // Amounts are left zero
+  //     } else if (coupon.discount.rate) {
+  //       const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
+  //       discountNow = roundForDiscount(discountableNow * coupon.discount.rate);
+  //       discountNext = roundForDiscount(discountableNext * coupon.discount.rate);
+  //     } else if (coupon.discount.amount) {
+  //       const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);
+  //       // Falls back to zero if the coupon does not support the checkout currency
+  //       const discountAmount = coupon.discount.amount[this.items.currency] || 0;
+  //       discountNow = Math.min(discountableNow, discountAmount);
+  //       discountNext = Math.min(discountableNext, discountAmount);
+  //     }
+  //   }
+  //   return { discountNow, discountNext };
+  // }
   /**
    * Computes the discountable subtotals for a given coupon
    *

--- a/test/unit/pricing/checkout/checkout.test.js
+++ b/test/unit/pricing/checkout/checkout.test.js
@@ -1750,8 +1750,6 @@ describe('CheckoutPricing', function () {
         });
 
         describe('when a coupon is applied', () => {
-          describe('..', () => {
-
             beforeEach(function () {
               return this.pricing.coupon('coop-pct-all');
             });
@@ -1766,7 +1764,6 @@ describe('CheckoutPricing', function () {
                   assert.equal(price.next.taxes, '1.49');
                   done();
                 });
-            });
           });
 
           describe.only('is single-use and applies to subscriptions and adjustments with taxes', () => {

--- a/test/unit/pricing/checkout/checkout.test.js
+++ b/test/unit/pricing/checkout/checkout.test.js
@@ -1750,23 +1750,23 @@ describe('CheckoutPricing', function () {
         });
 
         describe('when a coupon is applied', () => {
-            beforeEach(function () {
-              return this.pricing.coupon('coop-pct-all');
-            });
-
-            it('taxes the discounted subtotal', function (done) {
-              this.pricing
-                .reprice()
-                .done(price => {
-                  // 8.75% of taxable amount: 21.99 (sub) + 40 (adj) - 9 (discount) = 52.99
-                  assert.equal(price.now.taxes, '4.64');
-                  // 8.75% of taxable amount: 19.99 (sub) - 3 (discount) = 16.99
-                  assert.equal(price.next.taxes, '1.49');
-                  done();
-                });
+          beforeEach(function () {
+            return this.pricing.coupon('coop-pct-all');
           });
 
-          describe.only('is single-use and applies to subscriptions and adjustments with taxes', () => {
+          it('taxes the discounted subtotal', function (done) {
+            this.pricing
+              .reprice()
+              .done(price => {
+                // 8.75% of taxable amount: 21.99 (sub) + 40 (adj) - 9 (discount) = 52.99
+                assert.equal(price.now.taxes, '4.64');
+                // 8.75% of taxable amount: 19.99 (sub) - 3 (discount) = 16.99
+                assert.equal(price.next.taxes, '1.49');
+                done();
+              });
+          });
+
+          describe('is single-use and applies to subscriptions and adjustments with taxes', () => {
             beforeEach(applyCoupon('coop-single-use'));
 
             it('discounts only the subscriptions now, and applies no discounts next cycle', function () {


### PR DESCRIPTION
When utilizing single-use coupons, the `next` object in RJS was miscalculating the tax, falling back on the `now` objects subtotal for calculations. This resulted in lower taxes for the `next` object.
![image](https://github.com/recurly/recurly-js/assets/8193683/adfc5c12-7ac0-4178-9cd6-19bb0e4bec0d)

Gating the logic of the `next` object's `discountAmount` behind whether `coupon.single_use` is being used ensures the next object's discount amount applies properly.