### PR TITLE
Collect Venmo Addresses from Braintree Gateway

### DIFF
--- a/lib/const/gateway-constants.js
+++ b/lib/const/gateway-constants.js
@@ -1,1 +1,1 @@
-export const BRAINTREE_CLIENT_VERSION = '3.96.0';
+export const BRAINTREE_CLIENT_VERSION = '3.96.1';

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -69,7 +69,13 @@ export class BraintreeStrategy extends VenmoStrategy {
         if (error) return this.fail('venmo-braintree-api-error', { cause: error });
         debug('Device data collector created');
         this.deviceFingerprint = collector.deviceData;
-        braintree.venmo.create({ client, allowDesktop: true }, (error, venmo) => {
+        console.log('creating venmo client');
+        braintree.venmo.create({
+          client,
+          allowDesktop: true,
+          collectCustomerBillingAddress: true,
+          collectCustomerShippingAddress: true,
+        }, (error, venmo) => {
           if (error) return this.fail('venmo-braintree-api-error', { cause: error });
           debug('Venmo client created');
           this.venmo = venmo;


### PR DESCRIPTION
This PR adds flags to the Braintree Venmo client to collect the Shipping and Billing Addresses during the creation of a Braintree Venmo Nonce token. It also updates the Braintree client version in order to allow this functionality.