### PR TITLE
Collect Venmo Addresses from Braintree Gateway

### DIFF
--- a/lib/const/gateway-constants.js
+++ b/lib/const/gateway-constants.js
@@ -1,1 +1,1 @@
-export const BRAINTREE_CLIENT_VERSION = '3.96.1';
+export const BRAINTREE_CLIENT_VERSION = '3.96.0';

--- a/lib/const/gateway-constants.js
+++ b/lib/const/gateway-constants.js
@@ -1,1 +1,1 @@
-export const BRAINTREE_CLIENT_VERSION = '3.96.0';
+export const BRAINTREE_CLIENT_VERSION = '3.96.1';

--- a/lib/recurly/request.js
+++ b/lib/recurly/request.js
@@ -303,7 +303,7 @@ export class Request {
 
       // XDR requests will abort if too many are sent simultaneously
       setTimeout(() => {
-        if (method === 'post') {
+        if (method === 'post' || method === 'put') {
           // XDR cannot set Content-type
           if (req.setRequestHeader) {
             req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -69,7 +69,13 @@ export class BraintreeStrategy extends VenmoStrategy {
         if (error) return this.fail('venmo-braintree-api-error', { cause: error });
         debug('Device data collector created');
         this.deviceFingerprint = collector.deviceData;
-        braintree.venmo.create({ client, allowDesktop: true }, (error, venmo) => {
+        console.log('creating venmo client');
+        braintree.venmo.create({
+          client,
+          allowDesktop: true,
+          collectCustomerBillingAddress: true,
+          collectCustomerShippingAddress: true,
+        }, (error, venmo) => {
           if (error) return this.fail('venmo-braintree-api-error', { cause: error });
           debug('Venmo client created');
           this.venmo = venmo;

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -2,10 +2,10 @@ import loadScript from 'load-script';
 import after from '../../../util/after';
 import { VenmoStrategy } from './index';
 import { normalize } from '../../../util/normalize';
-import { BRAINTREE_CLIENT_VERSION } from '../../../const/gateway-constants';
 
 const debug = require('debug')('recurly:paypal:strategy:braintree');
 
+const BRAINTREE_CLIENT_VERSION = '3.96.1';
 /**
  * Braintree-specific Venmo handler
  */

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -22,6 +22,7 @@ export class BraintreeStrategy extends VenmoStrategy {
       throw this.error('venmo-config-missing', { opt: 'braintree.clientAuthorization' });
     }
     this.config.clientAuthorization = options.braintree.clientAuthorization;
+    this.config.allowDesktopWebLogin = options.braintree.webAuthentication ? options.braintree.webAuthentication : false;
   }
 
   /**
@@ -61,6 +62,7 @@ export class BraintreeStrategy extends VenmoStrategy {
 
     const authorization = this.config.clientAuthorization;
     const braintree = window.braintree;
+    const allowDesktopWebLogin = this.config.allowDesktopWebLogin;
 
     braintree.client.create({ authorization }, (error, client) => {
       if (error) return this.fail('venmo-braintree-api-error', { cause: error });
@@ -73,6 +75,8 @@ export class BraintreeStrategy extends VenmoStrategy {
         braintree.venmo.create({
           client,
           allowDesktop: true,
+          allowDesktopWebLogin:  allowDesktopWebLogin,
+          paymentMethodUsage: 'multi_use',
           collectCustomerBillingAddress: true,
           collectCustomerShippingAddress: true,
         }, (error, venmo) => {

--- a/lib/recurly/venmo/strategy/braintree.js
+++ b/lib/recurly/venmo/strategy/braintree.js
@@ -2,10 +2,10 @@ import loadScript from 'load-script';
 import after from '../../../util/after';
 import { VenmoStrategy } from './index';
 import { normalize } from '../../../util/normalize';
+import { BRAINTREE_CLIENT_VERSION } from '../../../const/gateway-constants';
 
 const debug = require('debug')('recurly:paypal:strategy:braintree');
 
-const BRAINTREE_CLIENT_VERSION = '3.96.1';
 /**
  * Braintree-specific Venmo handler
  */

--- a/test/unit/apple-pay.test.js
+++ b/test/unit/apple-pay.test.js
@@ -64,7 +64,7 @@ ApplePaySessionStub.canMakePayments = () => true;
 
 const getBraintreeStub = () => ({
   client: {
-    VERSION: '3.96.0',
+    VERSION: '3.96.1',
     create: sinon.stub().resolves('CLIENT'),
   },
   dataCollector: {

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -261,6 +261,18 @@ describe('Request', () => {
           });
         });
 
+        describe('when performing a PUT request', () => {
+          beforeEach(function (done) {
+            const proceed = () => done();
+            this.request.request({ method: 'put', route: '/test', data: this.example }).done(proceed, proceed);
+          });
+
+          it('sends properly-encoded data in the request body', function () {
+            assert(this.XHR.prototype.open.calledWithExactly('put', `${this.recurly.config.api}/test`));
+            assert(this.XHR.prototype.send.calledWithExactly(this.exampleEncoded()));
+          });
+        });
+
         describe('when performing a GET request', () => {
           beforeEach(function (done) {
             const proceed = () => done();


### PR DESCRIPTION
This PR adds flags to the Braintree Venmo client to collect the Shipping and Billing Addresses during the creation of a Braintree Venmo Nonce token. It also updates the Braintree client version in order to allow this functionality.