### PR TITLE
Update ApplePayPaymentAuthorizedEvent type to match actual object shape

### DIFF
--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -362,6 +362,7 @@ export type ApplePayPayment = {
    * The shipping contact selected by the user for this transaction.
    */
   shippingContact: ApplePayPaymentContact;
+  recurlyToken: TokenPayload;
 };
 
 /**
@@ -374,5 +375,4 @@ export type ApplePayPaymentAuthorizedEvent = {
   payment: ApplePayPayment;
 
   gatewayToken?: string;
-  recurlyToken: TokenPayload;
 };


### PR DESCRIPTION
Per [this file](https://github.com/recurly/recurly-js/blob/master/lib/recurly/apple-pay/apple-pay.js#L394), `recurlyToken` is attached to the `payment` field.