### PR TITLE
Handle Amazon Pay 3DS action tokens

### DIFF
--- a/lib/recurly/amazon/amazon-pay.js
+++ b/lib/recurly/amazon/amazon-pay.js
@@ -24,6 +24,7 @@ class AmazonPay extends Emitter {
     return this.recurly.request.get({ route: '/amazon_pay/button_render', data: { region: this.options.region } })
       .then((data) => {
         this.options.merchantId = data.merchant_id;
+        this.options.sandbox = data.sandbox;
       });
   }
 

--- a/lib/recurly/risk/three-d-secure/strategy/amazon.js
+++ b/lib/recurly/risk/three-d-secure/strategy/amazon.js
@@ -1,0 +1,53 @@
+import ThreeDSecureStrategy from './strategy';
+import { Frame } from '../../../frame';
+
+const debug = require('debug')('recurly:risk:three-d-secure:amazon');
+
+export default class AmazonStrategy extends ThreeDSecureStrategy {
+  static strategyName = 'amazon';
+
+  constructor (...args) {
+    super(...args);
+    this.markReady();
+  }
+
+  get redirectParams () {
+    return this.actionToken.three_d_secure.params.redirect;
+  }
+
+  /**
+   * Provides the target DOM element for which we will apply
+   * fingerprint detection, challenge flows, and results.
+   *
+   * @param {HTMLElement} element
+   */
+  attach (element) {
+    super.attach(element);
+    debug('Initiating 3D Secure frame');
+
+    const { redirectParams, container, threeDSecure } = this;
+    const { recurly } = threeDSecure.risk;
+    const payload = {
+      redirect_url: redirectParams.url,
+      three_d_secure_action_token_id: this.actionToken.id
+    };
+
+    this.frame = recurly.Frame({
+      path: '/three_d_secure/start',
+      payload,
+      container,
+      type: Frame.TYPES.WINDOW,
+      defaultEventName: 'amazon-3ds-challenge'
+    }).on('error', cause => threeDSecure.error('3ds-auth-error', { cause }))
+      .on('done', results => this.emit('done', results));
+  }
+
+  /**
+   * Removes DOM elements
+   */
+  remove () {
+    const { frame } = this;
+    if (frame) frame.destroy();
+    super.remove();
+  }
+}

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -12,6 +12,7 @@ import WirecardStrategy from './strategy/wirecard';
 import WorldpayStrategy from './strategy/worldpay';
 import OrbitalStrategy from './strategy/orbital';
 import PayPalCompleteStrategy from './strategy/paypal-complete';
+import AmazonStrategy from './strategy/amazon';
 
 const debug = require('debug')('recurly:risk:three-d-secure');
 
@@ -52,6 +53,7 @@ export class ThreeDSecure extends RiskConcern {
     WorldpayStrategy,
     OrbitalStrategy,
     PayPalCompleteStrategy,
+    AmazonStrategy,
   ];
 
   static CHALLENGE_WINDOW_SIZE_01_250_X_400 = '01';


### PR DESCRIPTION
Amazon Pay transactions created against the Amazon UK and Amazon EU regions can trigger 3DS. 
This new class allows us to handle presenting the challenge to customers.