### PR TITLE
Co-badge card support

### DIFF
--- a/lib/recurly/element/element.js
+++ b/lib/recurly/element/element.js
@@ -65,6 +65,7 @@ export default class Element extends Emitter {
     this.on(this.messageName('tab:previous'), () => this.onTab('previous'));
     this.on(this.messageName('tab:next'), () => this.onTab('next'));
     this.on(this.messageName('submit'), () => this.onSubmit());
+    this.on(this.messageName('coBadge:ready'), (...args) => this.notifyCoBadgeResult(...args));
     this.on('destroy', (...args) => this.destroy(...args));
     debug('create', this.id);
   }
@@ -167,6 +168,7 @@ export default class Element extends Emitter {
    */
   get url () {
     const config = encodeURIComponent(JSON.stringify(this.config));
+
     return this.recurly.url(`/field.html#config=${config}`);
   }
 
@@ -345,6 +347,7 @@ export default class Element extends Emitter {
    */
   messageName (name) {
     return `element:${this.id}:${name}`;
+    // element:21940812094ankfjankfawfwa:name
   }
 
   /**
@@ -404,6 +407,10 @@ export default class Element extends Emitter {
   onSubmit () {
     debug('submit', this.id);
     this.emit('submit', this);
+  }
+
+  notifyCoBadgeResult (body) {
+    this.emit('coBadge', { coBadgeSupport: body.coBadgeSupport, supportedBrands: body.supportedBrands });
   }
 }
 

--- a/lib/recurly/token.js
+++ b/lib/recurly/token.js
@@ -27,6 +27,7 @@ export const NON_ADDRESS_FIELDS = [
   'tax_identifier_type',
   'fraud_session_id',
   'token',
+  'card_network_preference',
 ];
 
 /**


### PR DESCRIPTION
Support for Co-Badged cards. RJS will now emit an event, 'coBadge' that devs can listen for to display to their customers. This event will emit only for cards that support two networks. Customers should be presented these options and then select a preferred network which can be passed in the tokenization call via the attribute `data_recurly` with a value of `card_network_preference`.