### PR TITLE
fix: Amazon Pay should be emitting the 'cancel' event when the window is manually closed

### DIFF
--- a/lib/recurly/amazon/amazon-pay.js
+++ b/lib/recurly/amazon/amazon-pay.js
@@ -68,7 +68,7 @@ class AmazonPay extends Emitter {
       type: Frame.TYPES.WINDOW,
       defaultEventName
     }).on('error', cause => this.emit('error', cause)) // Emitted by js/v1/amazon_pay/cancel
-      .on('close', () => this.emit('error', 'closed')) // Emitted by RJS Frame when the window is manually closed
+      .on('close', () => this.emit('cancel')) // Emitted by RJS Frame when the window is manually closed
       .on('done', results => this.emit('token', results)); // Emitted by js/v1/amazon_pay/finish
   }
 

--- a/types/lib/amazon-pay.d.ts
+++ b/types/lib/amazon-pay.d.ts
@@ -17,7 +17,7 @@ export type AmazonPayOptions = {
   sandbox?: boolean;
 };
 
-export type AmazonPayEvent = 'ready' | 'token' | 'error' | 'close' | 'done';
+export type AmazonPayEvent = 'ready' | 'token' | 'error' | 'cancel' | 'done';
 
 export interface AmazonPayInstance extends Emitter<AmazonPayEvent> {
   /**


### PR DESCRIPTION
The AmazonPay window was incorrectly emitting an `error` event when the user manually closed the recurly window frame. The `cancel` event should be emitted instead.