### PR TITLE
Adds billing address override to CashApp implementation

### DIFF
--- a/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
+++ b/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
@@ -35,7 +35,7 @@ class AlternativePaymentMethods extends Emitter {
   async submit ({ billingAddress } = {}) {
     this.validateBillingAddress(billingAddress);
     if (this.gatewayStrategy.data?.paymentMethod?.type == 'cashapp') {
-      return await this.gatewayStrategy.submitWebComponent();
+      return await this.gatewayStrategy.submitWebComponent(billingAddress);
     }
     try {
       const token = await this.tokenizePaymentMethod({ billingAddress });

--- a/lib/recurly/alternative-payment-methods/gateways/adyen.js
+++ b/lib/recurly/alternative-payment-methods/gateways/adyen.js
@@ -7,6 +7,7 @@ class AdyenGateway extends Base {
     this.state = {};
     this.gatewayType = 'adyen';
     this.webComponent = undefined;
+    this.customerBillingAddress = undefined;
   }
 
   scripts () {
@@ -59,17 +60,8 @@ class AdyenGateway extends Base {
         this.state = state;
         this.emit('change', state.isValid);
       },
-      onSubmit: state => {
-        this.state = state;
-        this.tokenizePaymentMethod({}).then(token => {
-          this.emit('token', token);
-        }).catch(err => {
-          this.emit('error', err);
-        });
-      },
-      onError: err => {
-        this.emit('error', err);
-      },
+      onSubmit: state => this.onWebComponentSubmit(state),
+      onError: err => this.emit('error', err),
     });
 
     this.webComponent = checkout
@@ -91,11 +83,12 @@ class AdyenGateway extends Base {
     return this.webComponent.handleAction(action);
   }
 
-  async submitWebComponent () {
+  async submitWebComponent (billingAddress) {
+    this.customerBillingAddress = billingAddress;
     return this.webComponent.submit();
   }
 
-  async tokenizePaymentMethod ({ billingAddress }) {
+  async tokenizePaymentMethod () {
     return this.recurly.request.post({
       route: '/payment_methods/token',
       data: {
@@ -107,8 +100,17 @@ class AdyenGateway extends Base {
         paymentMethodData: this.data,
         gatewayType: this.gatewayType,
         returnURL: this.options.returnURL,
-        billingAddress,
+        billingAddress: this.customerBillingAddress,
       },
+    });
+  }
+
+  onWebComponentSubmit (state) {
+    this.state = state;
+    this.tokenizePaymentMethod().then(token => {
+      this.emit('token', token);
+    }).catch(err => {
+      this.emit('error', err);
     });
   }
 }

--- a/types/lib/alternative-payment-methods.d.ts
+++ b/types/lib/alternative-payment-methods.d.ts
@@ -1,3 +1,4 @@
+import { Address } from './address';
 import { Emitter } from './emitter';
 
 export type AlternativePaymentMethodEvents = 'token' | 'error' | 'valid';
@@ -31,7 +32,7 @@ export type AdyenAlternativePaymentMethodOptions = {
   componentConfig?: { [key: string]: any }
 };
 
-export type AlternativePaymentMethodOptions = {
+export type AlternativePaymentMethodStartOptions = {
   /**
    * List of payment methods to be presented to the customer.
    */
@@ -79,18 +80,25 @@ export type AlternativePaymentMethodOptions = {
   adyen?: AdyenAlternativePaymentMethodOptions
 };
 
+export type AlternativePaymentMethodSubmitOptions = {
+  /**
+   * Sets the customer billing address on the generated token.
+   */
+  billingAddress?: Address;
+};
+
 export interface AlternativePaymentMethodsInstance extends Emitter<AlternativePaymentMethodEvents> {
   /**
    * Start the PaymentMethods and render the components.
    */
-  start: (data: AlternativePaymentMethodOptions) => Promise<void>;
+  start: (data: AlternativePaymentMethodStartOptions) => Promise<void>;
 
   /**
    * Submit the customer payment information and produce a token.
    * Call this function only when the payment information provided by the customer is valid, by listening the 'valid' event.
    * The token can be retrieved through the 'token' event.
    */
-  submit: () => Promise<void>;
+  submit: (args: AlternativePaymentMethodSubmitOptions) => Promise<void>;
 
   /**
    * Some payment methods require additional action from the shopper such as: to scan a QR code,


### PR DESCRIPTION
Allows any `billingAddress` applied to an `AlternativePaymentMethods#submit` call to be applied to tokens generated with CashApp.