### PR TITLE
Add destroy method for AlternatePaymentMethod class

### DIFF
--- a/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
+++ b/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
@@ -120,6 +120,11 @@ class AlternativePaymentMethods extends Emitter {
     });
   }
 
+  async destroy () {
+    this.gatewayStrategy.destroy();
+  }
+  
+
   async selectGatewayStrategy (gatewayType) {
     const gatewayClass = GATEWAYS[gatewayType];
 

--- a/lib/recurly/alternative-payment-methods/gateways/adyen.js
+++ b/lib/recurly/alternative-payment-methods/gateways/adyen.js
@@ -79,6 +79,11 @@ class AdyenGateway extends Base {
     return this.webComponent;
   }
 
+  async destroy () {
+    this.webComponent?.remove();
+    delete this.webComponent;
+  }
+
   get data () {
     const methodState = this.state.data;
     const componentState = this.webComponent?.activePaymentMethod?.data;

--- a/test/unit/alternative-payment-methods/alternative-payment-methods.test.js
+++ b/test/unit/alternative-payment-methods/alternative-payment-methods.test.js
@@ -103,6 +103,18 @@ describe('Recurly.AlternativePaymentMethods', () => {
       });
     });
 
+    describe('destroy', () => {
+      it('removes the web component', done => {
+        paymentMethods = recurly.AlternativePaymentMethods(params);
+        paymentMethods.start()
+          .then(() => {
+            paymentMethods.destroy();
+            assert.equal(paymentMethods.webComponent, undefined);
+          })
+          .finally(done);
+      });
+    });
+
     it("make a GET /js/v1/payment_methods/list with the needed params", (done) => {
       sandbox.stub(recurly.request, 'get').resolves({ });
       paymentMethods = recurly.AlternativePaymentMethods(params);


### PR DESCRIPTION
Adds destroy method to `alternative-payment-methods`. Calling this method removes and destroys the adyen web component, allowing it to subsequently be re-rendered without a page reload.