### PR TITLE
add currency to proactive preflights flow

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/braintree.js
+++ b/lib/recurly/risk/three-d-secure/strategy/braintree.js
@@ -11,7 +11,7 @@ export default class BraintreeStrategy extends ThreeDSecureStrategy {
   }
 
   static preflight ({ recurly, number, month, year, cvv }) {
-    const { enabled, gatewayCode, amount } = recurly.config.risk.threeDSecure.proactive;
+    const { enabled, gatewayCode, amount, currency } = recurly.config.risk.threeDSecure.proactive;
 
     debug('performing preflight for', { gatewayCode });
 
@@ -22,6 +22,7 @@ export default class BraintreeStrategy extends ThreeDSecureStrategy {
     const data = {
       gateway_type: BraintreeStrategy.strategyName,
       gateway_code: gatewayCode,
+      currency: currency,
       number,
       month,
       year,


### PR DESCRIPTION
Send the new param, `currency`. in the Proactive Braintree Preflights flow.