### PR TITLE
Allow gateway code to set specific gateway for paypal complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ docker compose up
 If you are having issues with the build, try `make clean`.
 
 ## Test
+
 ```bash
 $ make test
 ```
+
+To run a single test or test group, use mocha's `.only` syntax.
 
 ## License
 

--- a/lib/recurly/paypal/strategy/complete.js
+++ b/lib/recurly/paypal/strategy/complete.js
@@ -11,8 +11,16 @@ export class CompleteStrategy extends PayPalStrategy {
     this.emit('ready');
   }
 
+  get payload () {
+    let payload = {};
+    if (this.config.gatewayCode) payload.gatewayCode = this.config.gatewayCode;
+    return payload;
+  }
+
   start () {
-    const frame = this.frame = this.recurly.Frame({ path: PAYPAL_COMPLETE_START_PATH });
+    const { payload } = this;
+    const frame = this.frame = this.recurly.Frame({ path: PAYPAL_COMPLETE_START_PATH, payload });
+
     frame.once('done', token => this.emit('token', token));
     frame.once('close', () => this.emit('cancel'));
     frame.once('error', cause => {

--- a/test/types/paypal.ts
+++ b/test/types/paypal.ts
@@ -13,6 +13,11 @@ export default function paypal () {
     }
   });
 
+  window.recurly.PayPal({
+    gatewayCode: 'gateway-code',
+    payPalComplete: true,
+  });
+
   // @ts-expect-error
   window.recurly.PayPal('string');
 

--- a/test/unit/paypal/strategy/complete.test.js
+++ b/test/unit/paypal/strategy/complete.test.js
@@ -6,7 +6,7 @@ import {
 } from '../../support/helpers';
 
 describe('CompleteStrategy', function () {
-  const validOpts = { payPalComplete: true };
+  let validOpts;
 
   stubWindowOpen();
 
@@ -17,10 +17,37 @@ describe('CompleteStrategy', function () {
   });
 
   describe('start', function () {
+    validOpts = { payPalComplete: true };
+
     it('opens iframe with PayPal Complete start path', function () {
       this.sandbox.spy(this.recurly, 'Frame');
       this.paypal.start();
-      assert(this.recurly.Frame.calledWith({ path: '/paypal_complete/start' }));
+
+      assert(this.recurly.Frame.calledWith(sinon.match({
+        path: '/paypal_complete/start',
+        payload: {}
+      })));
+    });
+
+    context('when given a gateway code', function () {
+      const gatewayCode = 'qn1234a5bcde';
+      validOpts = { payPalComplete: true,  gatewayCode: gatewayCode };
+
+
+      it('Passes the description and gateway code to the API start endpoint', function () {
+        this.sandbox.spy(this.recurly, 'Frame');
+        this.paypal.start();
+
+        assert(this.recurly.Frame.calledOnce);
+
+        assert(this.recurly.Frame.calledWith(sinon.match({
+          path: '/paypal_complete/start',
+          payload: {
+            gatewayCode: gatewayCode
+          }
+        })));
+      });
     });
   });
 });
+

--- a/types/lib/paypal.d.ts
+++ b/types/lib/paypal.d.ts
@@ -30,6 +30,7 @@ export type DirectConfig = {
 export type PayPalCompleteConfig = {
   payPalComplete?: boolean;
   display?: PayPalDisplayConfig;
+  gatewayCode?: string;
 };
 
 export type PayPalConfig = BraintreeConfig | DirectConfig | PayPalCompleteConfig;


### PR DESCRIPTION
Allow users to set `config.gatewayCode` for paypal complete similar to paypal direct.

Sample usage 

```javascript
paypal = recurly.PayPal({
  payPalComplete: true
});

paypalComplete.strategy.config.gatewayCode = 'wrfnlillojd9'
```