### PR TITLE
fix(types): `ApplePayPaymentRequest.supportedNetworks` is an array

### DIFF
--- a/types/lib/apple-pay/native.d.ts
+++ b/types/lib/apple-pay/native.d.ts
@@ -197,7 +197,7 @@ export type ApplePayPaymentRequest = {
    * The payment networks the merchant supports. Only selects those networks that intersect with the merchant's
    * payment gateways configured in Recurly.
    */
-  supportedNetworks?: string;
+  supportedNetworks?: string[];
 
   /**
    * The fields of shipping information the user must provide to fulfill the order.


### PR DESCRIPTION
https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/supportednetworks

Closes https://github.com/recurly/recurly-js/issues/917