### PR TITLE
chore: parallelize preflights

### DIFF
--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -106,26 +106,31 @@ export class ThreeDSecure extends RiskConcern {
    * @return {Promise}
    */
   static preflight ({ recurly, number, month, year, cvv, preflights, addressFields, token }) {
-    return preflights.reduce((preflight, result) => {
-      return preflight.then((finishedPreflights) => {
+    return Promise.all(
+      preflights.map((result) => {
         const { type: gatewayType } = result.gateway;
         const { gateway_code } = result.params;
         const strategy = ThreeDSecure.getStrategyForGatewayType(gatewayType);
         return strategy.preflight({ recurly, number, month, year, cvv, addressFields, token, ...result.params })
           .then((preflightResponse) => {
-            if (!preflightResponse) return finishedPreflights;
+            if (!preflightResponse) return null;
             const { results, tokenType } = preflightResponse;
-            return {
-              tokenType: finishedPreflights.tokenType || tokenType,
-              risk: finishedPreflights.risk.concat({
-                processor: gatewayType,
-                gateway_code,
-                results
-              })
-            };
+            return { processor: gatewayType, gateway_code, results, tokenType };
           });
-      });
-    }, Promise.resolve({ risk: [] }));
+      })
+    ).then((responses) => {
+      return responses.reduce((acc, response) => {
+        if (!response) return acc;
+        return {
+          tokenType: acc.tokenType || response.tokenType,
+          risk: acc.risk.concat({
+            processor: response.processor,
+            gateway_code: response.gateway_code,
+            results: response.results
+          })
+        };
+      }, { risk: [] });
+    });
   }
 
   constructor ({ risk, actionTokenId, challengeWindowSize }) {

--- a/test/unit/risk/three-d-secure.test.js
+++ b/test/unit/risk/three-d-secure.test.js
@@ -137,6 +137,37 @@ describe('ThreeDSecure', function () {
         });
       });
     });
+
+    context('when multiple preflights are provided', function () {
+      beforeEach(function () {
+        this.preflights = [
+          { gateway: { type: 'gateway-a' }, params: { gateway_code: 'code-a' } },
+          { gateway: { type: 'gateway-b' }, params: { gateway_code: 'code-b' } }
+        ];
+
+        const calls = this.calls = [];
+        this.sandbox.stub(ThreeDSecure, 'getStrategyForGatewayType').callsFake((gatewayType) => ({
+          preflight: () => new Promise(resolve => {
+            calls.push({ gatewayType, resolve });
+          })
+        }));
+      });
+
+      it('runs all preflights in parallel', function (done) {
+        const { recurly, bin, preflights, calls } = this;
+        ThreeDSecure.preflight({ recurly, bin, preflights }).done(({ risk }) => {
+          assert.strictEqual(risk.length, 2);
+          assert.strictEqual(risk[0].processor, 'gateway-a');
+          assert.strictEqual(risk[1].processor, 'gateway-b');
+          done();
+        });
+
+        // Both preflights must have started before either resolves
+        assert.strictEqual(calls.length, 2, 'both preflights should start before either resolves');
+        calls[0].resolve({ results: { data: 'a' } });
+        calls[1].resolve({ results: { data: 'b' } });
+      });
+    });
   });
 
   it('adds itself to the provided Risk instance', function () {


### PR DESCRIPTION
For merchants that have many gateways with preflights, running them serially can take a while given they interact with the gateway.

This runs the preflight checks in parallel.