### PR TITLE
ci: Remediate Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Lint
         run: make lint
       - name: Lint types
@@ -27,8 +27,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v4
         with:
           languages: javascript
           config: |
@@ -39,13 +39,17 @@ jobs:
               - '**/*test*'
           queries: + security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         continue-on-error: true
         with:
           category: /language:javascript
   test_local:
     name: ${{matrix.test-type}} test (${{matrix.browser}})
     runs-on: ubuntu-latest
+    env:
+      # TODO(SWI-5336): coactions/setup-xvfb has no node24 release yet (latest: v1.0.1 still uses node16).
+      # Remove once a node24-compatible version is available upstream.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
       matrix:
@@ -56,12 +60,12 @@ jobs:
           - Chrome
           - Firefox
     steps:
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@v2
       - uses: browser-actions/setup-firefox@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Unit test
         if: ${{matrix.test-type == 'Unit'}}
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@v1.0.1
         env:
           BROWSER: ${{matrix.browser}}
           DISPLAY: :99
@@ -69,7 +73,7 @@ jobs:
           run: make test-unit-ci
       - name: End-to-end test
         if: ${{matrix.test-type == 'End-to-end'}}
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@v1.0.1
         env:
           BROWSER: ${{matrix.browser}}
           DISPLAY: :99
@@ -77,7 +81,7 @@ jobs:
           run: make test-e2e-ci
       - name: Upload visual regression artifacts
         if: ${{failure() && matrix.test-type == 'End-to-end'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-regression-${{matrix.browser}}-${{github.run_id}}
           path: tmp/
@@ -102,10 +106,10 @@ jobs:
           - Android-12-Remote
     steps:
       - uses: ahmadnassri/action-workflow-queue@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Unit test
         if: ${{matrix.test-type == 'Unit'}}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v4
         env:
           BROWSER: ${{matrix.browser}}
           BROWSER_STACK_USERNAME: ${{secrets.BROWSER_STACK_USERNAME}}
@@ -116,7 +120,7 @@ jobs:
           command: make test-unit-ci
       - name: End-to-end test
         if: ${{matrix.test-type == 'End-to-end'}}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v4
         env:
           BROWSER: ${{matrix.browser}}
           BROWSER_STACK_USERNAME: ${{secrets.BROWSER_STACK_USERNAME}}
@@ -127,7 +131,7 @@ jobs:
           command: make test-e2e-ci
       - name: Upload visual regression artifacts
         if: ${{failure() && matrix.test-type == 'End-to-end'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-regression-${{matrix.browser}}-${{github.run_id}}
           path: tmp/
@@ -136,7 +140,7 @@ jobs:
     name: Integration test with react-recurly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: recurly/react-recurly
           path: vendor
@@ -171,28 +175,32 @@ jobs:
   publish:
     name: Publish artifacts
     runs-on: ubuntu-latest
+    env:
+      # TODO(SWI-5336): coactions/setup-xvfb has no node24 release yet (latest: v1.0.1 still uses node16).
+      # Remove once a node24-compatible version is available upstream.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     needs:
       - lint
       - analyze
       - test_local
       - test_remote
     steps:
-      - uses: actions/checkout@v3
-      - uses: browser-actions/setup-chrome@v1
+      - uses: actions/checkout@v6
+      - uses: browser-actions/setup-chrome@v2
       - name: Build
         run: make build
       - name: Report coverage
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@v1.0.1
         env:
           COVERALLS_REPO_TOKEN: ${{secrets.COVERALLS_REPO_TOKEN}}
           DISPLAY: :99
         with:
           run: make test-unit-cov-ci
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{secrets.GCR_QA_PUBLIC_DEVOPS_SA}}
       - name: Upload to Google Cloud Storage
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: build
           destination: ${{secrets.ARTIFACT_BUCKET_NAME}}/recurly-js/${{github.sha}}/
@@ -200,7 +208,7 @@ jobs:
           process_gcloudignore: false
       - name: Upload to Google Cloud Storage for pull requests
         if: ${{github.event_name == 'pull_request'}}
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: build
           destination: ${{secrets.ARTIFACT_BUCKET_NAME}}/recurly-js/pull-request--${{github.event.number}}/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ concurrency:
   group: '${{github.workflow}} @ ${{github.head_ref || github.ref_name}}'
   cancel-in-progress: true
 
+env:
+  # TODO(SWI-5336): Temporary — forces all JS actions to node24 for validation. Remove before merge.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,6 @@ concurrency:
   group: '${{github.workflow}} @ ${{github.head_ref || github.ref_name}}'
   cancel-in-progress: true
 
-env:
-  # TODO(SWI-5336): Temporary — forces all JS actions to node24 for validation. Remove before merge.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -4,10 +4,6 @@ on:
     types:
       - published
 
-env:
-  # TODO(SWI-5336): Temporary — forces all JS actions to node24 for validation. Remove before merge.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   Publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Recurly-js
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           path: recurly-js
       - name: Checkout DefinitelyTyped
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: DefinitelyTyped/DefinitelyTyped
           ref: master
@@ -34,7 +34,7 @@ jobs:
           out_version=$(cat recurly-js/package.json | jq '.version' -r )
           echo ::set-output name=version::$out_version
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           path: DefinitelyTyped
           commit-message: Updates recurly-js types

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -4,6 +4,10 @@ on:
     types:
       - published
 
+env:
+  # TODO(SWI-5336): Temporary — forces all JS actions to node24 for validation. Remove before merge.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   Publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. All actions running on node20 or earlier will be forced to Node.js 24 on **June 16, 2026**. Node.js 20 will be removed from runners entirely in **Fall 2026**.

### Fix
Updated all workflow files in `.github/workflows/` to use Node.js 24-compatible action versions.

**Group A — clean upgrades (node24 available):**
| Action | From | To |
|--------|------|----|
| `actions/checkout` | `@v2` / `@v3` | `@v6` (node24) |
| `github/codeql-action/init` | `@v3` | `@v4` (node24) |
| `github/codeql-action/analyze` | `@v3` | `@v4` (node24) |
| `browser-actions/setup-chrome` | `@v1` | `@v2` (node24) |
| `actions/upload-artifact` | `@v4` | `@v7` (node24) |
| `nick-fields/retry` | `@v2` | `@v4` (node24) |
| `google-github-actions/auth` | `@v1` | `@v3` (node24) |
| `google-github-actions/upload-cloud-storage` | `@v1` | `@v3` (node24) |
| `peter-evans/create-pull-request` | `@v3` | `@v8` (node24) |

**Group B — workaround (no node24 release available yet):**
| Action | Deployed version | Node runtime | Workaround |
|--------|-----------------|--------------|------------|
| `coactions/setup-xvfb` | `@v1.0.1` (latest) | node16 | `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` at job level |

### Files Changed
- `.github/workflows/ci.yaml` — updated 10 actions across `lint`, `analyze`, `test_local`, `test_remote`, `integration_test`, and `publish` jobs; added `ACTIONS_ALLOW` workaround to `test_local` and `publish` job envs
- `.github/workflows/publish-types.yaml` — updated `actions/checkout@v2` → `@v6` (×2) and `peter-evans/create-pull-request@v3` → `@v8`

## Testing

Validated with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow `env:` level — forces all JS actions to run under node24. 

| Job | Actions validated | Result |
|-----|-------------------|--------|
| Lint | `checkout@v6` | ✅ pass |
| Analyze / CodeQL | `checkout@v6`, `codeql-action/init@v4`, `codeql-action/analyze@v4` | ✅ pass |
| Unit test (Chrome, Firefox) | `setup-chrome@v2`, `checkout@v6`, `setup-xvfb@v1.0.1` + `ACTIONS_ALLOW` | ✅ pass |
| End-to-end test (Chrome, Firefox) | `setup-chrome@v2`, `checkout@v6`, `setup-xvfb@v1.0.1`, `upload-artifact@v7` | ✅ pass |
| Unit/E2e test (Safari, Edge, iOS, Android) | `checkout@v6`, `retry@v4` | ✅ pass |
| Integration test with react-recurly | `checkout@v6` | ✅ pass |
| Publish artifacts | `checkout@v6`, `setup-chrome@v2`, `setup-xvfb@v1.0.1`, `auth@v3`, `upload-cloud-storage@v3` | ✅ pass |

**Not CI-testable:** `publish-types.yaml` is triggered only on `release` events. Actions involved (`checkout@v6` ×2, `create-pull-request@v8`) are validated in other workflows or are well-established node24 upgrades.

Note: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` will be removed before merge.

## Workaround Items
The following action has no node24-compatible release yet and requires a temporary workaround:

- `coactions/setup-xvfb@v1.0.1` — latest release (2022-12-19) still uses node16. `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` added to `test_local` and `publish` job envs in `ci.yaml`. Remove flag once upstream publishes a node24-compatible version.