### PR TITLE
fix(checkout-pricing): skip subscription discount for item-restricted coupons

### DIFF
--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -388,7 +388,7 @@ export default class Calculations {
     }
 
     // subscriptions
-    if (coupon.applies_to_plans && this.hasValidSubscriptions) {
+    if (coupon.applies_to_plans && !coupon.applies_to_items && this.hasValidSubscriptions) {
       let discountableSubscriptions;
 
       // subscription-level coupons may only apply to one subscription

--- a/packages/public-api-fixture-server/fixtures/coupons/coop-pct-items-and-adjustments.json
+++ b/packages/public-api-fixture-server/fixtures/coupons/coop-pct-items-and-adjustments.json
@@ -1,0 +1,15 @@
+{
+  "code": "coop-pct-items-and-adjustments",
+  "name": "Test coupon: 15% off non-plan charges, item-restricted, no subscription discount",
+  "discount": {
+    "rate": 0.15
+  },
+  "plans": [],
+  "single_use": false,
+  "applies_to_non_plan_charges": true,
+  "applies_to_plans": false,
+  "applies_to_all_plans": false,
+  "applies_to_items": true,
+  "item_codes": [],
+  "redemption_resource": "account"
+}

--- a/packages/public-api-fixture-server/fixtures/coupons/coop-pct-items-only.json
+++ b/packages/public-api-fixture-server/fixtures/coupons/coop-pct-items-only.json
@@ -1,0 +1,15 @@
+{
+  "code": "coop-pct-items-only",
+  "name": "Test coupon: 15% off, plan-applicable but restricted to item sales only",
+  "discount": {
+    "rate": 0.15
+  },
+  "plans": [],
+  "single_use": false,
+  "applies_to_non_plan_charges": false,
+  "applies_to_plans": true,
+  "applies_to_all_plans": true,
+  "applies_to_items": true,
+  "item_codes": [],
+  "redemption_resource": "account"
+}

--- a/test/unit/pricing/checkout/checkout.test.js
+++ b/test/unit/pricing/checkout/checkout.test.js
@@ -991,6 +991,44 @@ describe('CheckoutPricing', function () {
               assert.equal(this.price.next.discount, 0);
             });
           });
+
+          describe('item-restricted coupons (applies_to_items: true)', () => {
+            describe('given a coupon with applies_to_items absent (baseline — no regression)', () => {
+              beforeEach(applyCoupon('coop-pct-subscriptions'));
+              it('discounts subscriptions as normal', function () {
+                assert.equal(this.price.now.subscriptions, 43.98);
+                assert.equal(this.price.now.adjustments, 32.44);
+                assert.equal(this.price.now.discount, 6.0);
+                assert.equal(this.price.next.subscriptions, 39.98);
+                assert.equal(this.price.next.adjustments, 0);
+                assert.equal(this.price.next.discount, 6.0);
+              });
+            });
+
+            describe('given a coupon with applies_to_items true and applies_to_plans true', () => {
+              beforeEach(applyCoupon('coop-pct-items-only'));
+              it('does not discount subscriptions even though applies_to_plans is true', function () {
+                assert.equal(this.price.now.subscriptions, 43.98);
+                assert.equal(this.price.now.adjustments, 32.44);
+                assert.equal(this.price.now.discount, 0);
+                assert.equal(this.price.next.subscriptions, 39.98);
+                assert.equal(this.price.next.adjustments, 0);
+                assert.equal(this.price.next.discount, 0);
+              });
+            });
+
+            describe('given a coupon with applies_to_items true and applies_to_non_plan_charges true', () => {
+              beforeEach(applyCoupon('coop-pct-items-and-adjustments'));
+              it('discounts adjustments but not subscriptions', function () {
+                assert.equal(this.price.now.subscriptions, 43.98);
+                assert.equal(this.price.now.adjustments, 32.44);
+                assert.equal(this.price.now.discount, 4.87); // 15% of 32.44
+                assert.equal(this.price.next.subscriptions, 39.98);
+                assert.equal(this.price.next.adjustments, 0);
+                assert.equal(this.price.next.discount, 0);
+              });
+            });
+          });
         });
 
         /**


### PR DESCRIPTION
## Description

`CheckoutPricing` was computing a subscription discount whenever `coupon.applies_to_plans` was true, with no check for whether the coupon was restricted to item sales only (`applies_to_items`). An item-restricted coupon that also had `applies_to_plans` set would show a phantom discount on the subscription line during hosted checkout — a discount that the server correctly rejected at purchase, leaving customers confused.

Add an `&& !coupon.applies_to_items` guard to the subscription discount condition in `calculations.js`. The `applies_to_items` field is present in the coupon API response when the server supports it; when absent (older responses), `!undefined` evaluates to `true`, preserving the existing behavior. Add two new fixtures and three new unit tests covering the bug scenario, a regression baseline, and the adjustment-only discount path.

## Testing

1. On a hosted checkout with a subscription-only cart, apply a coupon that has `applies_to_items: true` in the server response.
2. Confirm no subscription discount appears in the checkout preview.
3. Apply a regular (non-item-restricted) coupon — confirm subscription discount still appears correctly.
4. Run the unit tests:
   ```
   make test-unit-file FILES=test/unit/pricing/checkout/checkout.test.js
   ```