### PR TITLE
feat(pricing): support sub-cent add-on prices via unit_amount_decimal

### DIFF
--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -1,7 +1,7 @@
 import each from 'component-each';
 import find from 'component-find';
 import isEmpty from 'lodash.isempty';
-import { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
+import decimalize, { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
 import { getTieredPricingTotal, getTieredPricingUnitAmount, isTieredAddOn } from './tiered-pricing-calculator';
 
 /**
@@ -214,12 +214,20 @@ export default class Calculations {
         totalPrice = getTieredPricingTotal(addon, selectedQuantity, currencyCode);
         unitPrice = getTieredPricingUnitAmount(addon, selectedQuantity, currencyCode);
       } else {
-        unitPrice = addon.price[this.items.currency].unit_amount;
+        const currencyPrice = addon.price[this.items.currency];
+        unitPrice = currencyPrice.unit_amount_decimal != null
+          ? parseFloat(currencyPrice.unit_amount_decimal)
+          : currencyPrice.unit_amount;
         totalPrice = unitPrice * selectedQuantity;
       }
 
-      this.price.base.addons[addon.code] = unitPrice;
-      this.price.addons[addon.code] = totalPrice; // DEPRECATED
+      const preservePrecision = value => round(value, 9) !== round(value, 2);
+      this.price.base.addons[addon.code] = preservePrecision(unitPrice)
+        ? decimalize(unitPrice, 9)
+        : unitPrice;
+      this.price.addons[addon.code] = preservePrecision(totalPrice) // DEPRECATED
+        ? decimalize(totalPrice, 9)
+        : totalPrice;
 
       if (!this.isTrial) this.price.now.addons += totalPrice;
       this.price.next.addons += totalPrice;

--- a/lib/recurly/pricing/subscription/tiered-pricing-calculator.js
+++ b/lib/recurly/pricing/subscription/tiered-pricing-calculator.js
@@ -40,7 +40,9 @@ export function getTieredPricingValues (
       return null;
     }
 
-    const tierValue = tierCurrency.unit_amount;
+    const tierValue = tierCurrency.unit_amount_decimal != null
+      ? parseFloat(tierCurrency.unit_amount_decimal)
+      : tierCurrency.unit_amount;
     let startingValue;
 
     if (isFirstTier) {
@@ -129,5 +131,8 @@ export function getTieredPricingTotal (
  */
 export function getTieredPricingUnitAmount (addOn, selectedNumUnits, currencyCode) {
   const tier = find(addOn.tiers, (tier) => (selectedNumUnits || 1) <= tier.ending_quantity);
-  return find(tier.currencies, (currency) => currency.currency_code === currencyCode).unit_amount;
+  const tierCurrency = find(tier.currencies, (currency) => currency.currency_code === currencyCode);
+  return tierCurrency.unit_amount_decimal != null
+    ? parseFloat(tierCurrency.unit_amount_decimal)
+    : tierCurrency.unit_amount;
 }

--- a/lib/util/decimalize.js
+++ b/lib/util/decimalize.js
@@ -10,8 +10,11 @@ export function clampToZero (number) {
  * @return {Number}
  */
 export function round (number, digits = 2) {
-  const rounded = +((number < 0 ? -1 : 1) * Math.round(Math.abs(number) + 'e+2') + 'e-2');
-  return parseFloat(rounded.toFixed(digits));
+  const sign = number < 0 ? -1 : 1;
+  const [mantissa, exponent] = Math.abs(number).toExponential().split('e');
+  const shiftedExponent = Number(exponent) + digits;
+  const rounded = Math.round(Number(`${mantissa}e${shiftedExponent}`));
+  return sign * Number(`${rounded}e-${digits}`);
 }
 
 /**

--- a/packages/public-api-fixture-server/fixtures/plans/basic.json
+++ b/packages/public-api-fixture-server/fixtures/plans/basic.json
@@ -38,6 +38,58 @@
     "usage_percentage": null,
     "usage_type": null
   },{
+    "add_on_type": "fixed",
+    "name": "Sub-cent Addon",
+    "code": "sub-cent-addon",
+    "quantity": 1,
+    "tier_type": "flat",
+    "price": {
+      "USD": {
+        "unit_amount": 0.001234
+      }
+    },
+    "usage_percentage": null,
+    "usage_type": null
+  },{
+    "add_on_type": "fixed",
+    "name": "Sub-cent Decimal Addon",
+    "code": "sub-cent-decimal-addon",
+    "quantity": 1,
+    "tier_type": "flat",
+    "price": {
+      "USD": {
+        "unit_amount": 0,
+        "unit_amount_decimal": "0.001234"
+      }
+    },
+    "usage_percentage": null,
+    "usage_type": null
+  },{
+    "add_on_type": "fixed",
+    "name": "Sub-cent Tiny Decimal Addon",
+    "code": "sub-cent-tiny-decimal-addon",
+    "quantity": 1,
+    "tier_type": "flat",
+    "price": {
+      "USD": {
+        "unit_amount": 0,
+        "unit_amount_decimal": "0.000000123"
+      }
+    },
+    "usage_percentage": null,
+    "usage_type": null
+  },{
+    "add_on_type": "fixed",
+    "name": "Sub-cent Tiered Decimal Addon",
+    "code": "sub-cent-tiered-decimal-addon",
+    "quantity": 1,
+    "tier_type": "tiered",
+    "tiers": [
+      { "ending_quantity": 10, "currencies": [{ "currency_code": "USD", "unit_amount_decimal": "0.001234", "unit_amount": null }] },
+      { "ending_quantity": 999999999, "currencies": [{ "currency_code": "USD", "unit_amount_decimal": "0.000500", "unit_amount": null }] }
+    ],
+    "price": {}
+  },{
     "add_on_type": "usage",
     "code": "with_usage",
     "name": "WithUsage",

--- a/test/unit/pricing/subscription/subscription.test.js
+++ b/test/unit/pricing/subscription/subscription.test.js
@@ -217,6 +217,61 @@ describe('Recurly.Pricing.Subscription', function () {
 
   describe('with addons', () => {
     describe('with fixed addons', () => {
+      it('preserves sub-cent precision for a flat add-on (unit_amount path)', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .addon('sub-cent-addon', { quantity: 2 })
+          .done(price => {
+            assert.equal(price.base.addons['sub-cent-addon'], '0.001234000');
+            assert.equal(price.addons['sub-cent-addon'], '0.002468000');
+            done();
+          });
+      });
+
+      it('preserves sub-cent precision for a flat add-on (unit_amount_decimal path)', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .addon('sub-cent-decimal-addon', { quantity: 2 })
+          .done(price => {
+            assert.equal(price.base.addons['sub-cent-decimal-addon'], '0.001234000');
+            assert.equal(price.addons['sub-cent-decimal-addon'], '0.002468000');
+            done();
+          });
+      });
+
+      it('preserves sub-cent precision for a flat add-on with a value below 1e-6 (unit_amount_decimal path)', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .addon('sub-cent-tiny-decimal-addon', { quantity: 2 })
+          .done(price => {
+            assert.equal(price.base.addons['sub-cent-tiny-decimal-addon'], '0.000000123');
+            assert.equal(price.addons['sub-cent-tiny-decimal-addon'], '0.000000246');
+            done();
+          });
+      });
+
+      it('preserves sub-cent precision for a tiered add-on (unit_amount_decimal path)', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .addon('sub-cent-tiered-decimal-addon', { quantity: 2 })
+          .done(price => {
+            assert.equal(price.base.addons['sub-cent-tiered-decimal-addon'], '0.001234000');
+            assert.equal(price.addons['sub-cent-tiered-decimal-addon'], '0.002468000');
+            done();
+          });
+      });
+
+      it('emits standard 2-decimal output for a normal add-on', function (done) {
+        this.pricing
+          .plan('basic', { quantity: 1 })
+          .addon('snarf', { quantity: 1 })
+          .done(price => {
+            assert.equal(price.base.addons['snarf'], '1.00');
+            assert.equal(price.addons['snarf'], '1.00');
+            done();
+          });
+      });
+
       it('updates the price accordingly', function (done) {
         this.pricing
           .plan('basic', { quantity: 1 })


### PR DESCRIPTION
Fixed and flat add-on prices were displaying as -zsh.00 when priced below one cent. The Recurly API returns these prices in unit_amount_decimal (a string with up to 9 decimal places) while unit_amount is truncated to 0.)

-  Read unit_amount_decimal with unit_amount as fallback in the flat add-on path (calculations.js) and in tiered-pricing-calculator.js
-  Store per-add-on prices at 9-digit precision before decimalizeMember runs so the 2-place rounding pass does not truncate sub-cent values; decimalizeMember skips strings, so the stored value is preserved
-  Fix round() to correctly honor the digits parameter using the string-exponent trick; the previous implementation hardcoded e+2/e-2 making round(x, 9) always round to 2 decimal places
-  Add sub-cent-decimal-addon and sub-cent-tiered-decimal-addon fixtures with tests covering both unit_amount_decimal and unit_amount fallback code paths