### PR TITLE
Reduce E2E CI log noise

### DIFF
--- a/wdio.ci.conf.js
+++ b/wdio.ci.conf.js
@@ -65,6 +65,7 @@ if (useBrowserstack) {
 const config = {
   ...defaultConfig,
   ...{
+    logLevel: 'warn',
     capabilities: [
       {
         browserName: BROWSER
@@ -73,6 +74,7 @@ const config = {
     baseUrl: 'http://localhost:9877',
     maxInstances: 1,
     services: [visualService()],
+    reporters: [['spec', { onlyFailures: true }]],
     onPrepare: () => {
       if (useBrowserstack && isMobile()) {
         process.env.API_PROXY = 'http://bs-local.com:9877/api-proxy';


### PR DESCRIPTION
## Summary

- Sets `logLevel: 'warn'` in `wdio.ci.conf.js`, overriding the `'info'` inherited from `wdio.conf.js`. At `info`, WDIO logs every WebDriver HTTP request and response (URL, payload, status, body) — one pair per driver command, meaning hundreds of lines of protocol traffic per test run.
- Adds `reporters: [['spec', { onlyFailures: true }]]`. The spec reporter buffers per-spec output and skips the entire block when there are no failures. Failing suites still get full failure detail.

**Before:** CI logs are dominated by WebDriver HTTP traffic and per-test checkmarks for every passing test.  
**After:** Passing runs produce near-zero output; failing runs show exactly what broke.

## Test plan

- [ ] Trigger a CI run (or run `make test-e2e-ci` locally) — verify the log volume is dramatically reduced for passing tests
- [ ] Introduce a deliberate failure — verify the spec reporter still prints the full failure block with test name, error message, and stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)