### PR TITLE
 Add PayPay as a new Adyen APM

### DIFF
--- a/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
+++ b/lib/recurly/alternative-payment-methods/alternative-payment-methods.js
@@ -123,7 +123,6 @@ class AlternativePaymentMethods extends Emitter {
   async destroy () {
     if (this.gatewayStrategy) this.gatewayStrategy.destroy();
   }
-  
 
   async selectGatewayStrategy (gatewayType) {
     const gatewayClass = GATEWAYS[gatewayType];

--- a/test/types/alternative-payment-methods.ts
+++ b/test/types/alternative-payment-methods.ts
@@ -1,6 +1,6 @@
 export default function alternativePaymentMethods () {
   const apm = window.recurly.AlternativePaymentMethods({
-    allowedPaymentMethods: ['ideal', 'sofort', 'cashapp'],
+    allowedPaymentMethods: ['ideal', 'sofort', 'cashapp', 'paypay'],
     blockedPaymentMethods: ['bacs'],
     containerSelector: '#payment-methods',
     amount: 1000,

--- a/types/lib/alternative-payment-methods.d.ts
+++ b/types/lib/alternative-payment-methods.d.ts
@@ -3,7 +3,7 @@ import { Emitter } from './emitter';
 
 export type AlternativePaymentMethodEvents = 'token' | 'error' | 'valid';
 
-export type AlternativePaymentMethodType = 'boleto' | 'ideal' | 'sofort' | 'paypal' | 'cashapp' | 'bacs';
+export type AlternativePaymentMethodType = 'boleto' | 'ideal' | 'sofort' | 'paypal' | 'cashapp' | 'bacs' | 'paypay';
 
 export type ChannelType = 'iOS' | 'Android' | 'Web';
 


### PR DESCRIPTION
## Summary

- Adds `paypay` to the `AlternativePaymentMethodType` TypeScript union
- Adds `paypay` to the type-test's `allowedPaymentMethods` fixture


## Test plan

- [ ] Lint: `make lint` — ✅ passes
- [ ] Unit tests: `make test-unit` — ✅ 1274 passed, 0 failed

