### PR TITLE
fix: Round percentage coupon discounts in integer cents to match API

### DIFF
--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -2,7 +2,7 @@ import each from 'component-each';
 import isEmpty from 'lodash.isempty';
 import Promise from 'promise';
 import uniq from 'array-unique';
-import { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
+import { clampToZero, decimalizeMember, round, roundRateDiscount } from '../../../util/decimalize';
 import groupBy from '../../../util/group-by';
 
 /**
@@ -336,10 +336,10 @@ export default class Calculations {
         // Amounts are left zero
       } else if (coupon.discount.rate) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
-        discountNow = round(discountableNow * coupon.discount.rate, 6);
+        discountNow = roundRateDiscount(discountableNow, coupon.discount.rate);
         // If coupon is single use, we want discountNext to be zero
         if (!coupon.single_use) {
-          discountNext = round(discountableNext * coupon.discount.rate, 6);
+          discountNext = roundRateDiscount(discountableNext, coupon.discount.rate);
         }
       } else if (coupon.discount.amount) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -1,7 +1,7 @@
 import each from 'component-each';
 import find from 'component-find';
 import isEmpty from 'lodash.isempty';
-import { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
+import { clampToZero, decimalizeMember, round, roundRateDiscount } from '../../../util/decimalize';
 import { getTieredPricingTotal, getTieredPricingUnitAmount, isTieredAddOn } from './tiered-pricing-calculator';
 
 /**
@@ -240,10 +240,8 @@ export default class Calculations {
     if (!coupon) return;
 
     if (coupon.discount.rate) {
-      var discountNow = round(this.price.now.subtotal * coupon.discount.rate);
-      var discountNext = round(this.price.next.subtotal * coupon.discount.rate);
-      this.price.now.discount = discountNow;
-      this.price.next.discount = discountNext;
+      this.price.now.discount = roundRateDiscount(this.price.now.subtotal, coupon.discount.rate);
+      this.price.next.discount = roundRateDiscount(this.price.next.subtotal, coupon.discount.rate);
     } else if (coupon.discount.type === 'free_trial') {
       // Handled in separate trial logic
     } else {

--- a/lib/util/decimalize.js
+++ b/lib/util/decimalize.js
@@ -15,6 +15,22 @@ export function round (number, digits = 2) {
 }
 
 /**
+ * Rounds a rate (percentage) discount to the nearest cent the way the billing
+ * API does: the discountable amount is reduced to integer cents before the rate
+ * is applied, so a half-cent result rounds to the nearest cent instead of
+ * drifting down through floating point dollar math. For example 15% of 34.90 is
+ * 5.24, not 5.23 (34.90 * 0.15 evaluates to 5.234999… as a dollar float).
+ *
+ * @param {Number} amount discountable amount in the major unit (e.g. dollars)
+ * @param {Number} rate discount rate (e.g. 0.15)
+ * @return {Number} discount in the major unit, rounded to the nearest cent
+ */
+export function roundRateDiscount (amount, rate) {
+  const cents = Math.round(amount * 100) * rate;
+  return round(cents / 100);
+}
+
+/**
  * Applies a decimal transform on an object's member
  *
  * @param {String} prop Property on {this} to transform

--- a/packages/public-api-fixture-server/fixtures/plans/pct-tie-plan.json
+++ b/packages/public-api-fixture-server/fixtures/plans/pct-tie-plan.json
@@ -1,0 +1,17 @@
+{
+  "code": "pct-tie-plan",
+  "name": "Pct Tie Plan",
+  "period": {
+    "interval": "months",
+    "length": 1
+  },
+  "price": {
+    "USD": {
+      "unit_amount": 34.90,
+      "symbol": "$",
+      "setup_fee": 0
+    }
+  },
+  "addons": [],
+  "tax_exempt": false
+}

--- a/test/unit/pricing/checkout/checkout.test.js
+++ b/test/unit/pricing/checkout/checkout.test.js
@@ -873,6 +873,21 @@ describe('CheckoutPricing', function () {
           });
       });
 
+      // A percentage discount landing on a half cent must round up to the
+      // nearest cent, matching the API which computes the discount in integer
+      // cents. 15% of $34.90 is 523.5¢, so the discount is $5.24.
+      it('rounds a half-cent rate discount up to the nearest cent, matching the API', function (done) {
+        this.pricing
+          .adjustment({ amount: 34.90 })
+          .coupon('coop-pct-adjustments')
+          .reprice()
+          .done(price => {
+            assert.equal(price.now.discount, 5.24);
+            assert.equal(price.now.adjustments, 34.90);
+            done();
+          });
+      });
+
       describe('given a CheckoutPricing containing multiple subscriptions and adjustments', () => {
         beforeEach(function (done) {
           subscriptionPricingFactory('basic', this.recurly, sub => {

--- a/test/unit/pricing/subscription/subscription.test.js
+++ b/test/unit/pricing/subscription/subscription.test.js
@@ -635,6 +635,23 @@ describe('Recurly.Pricing.Subscription', function () {
         });
     });
 
+    // A percentage discount landing on a half cent must round up to the nearest
+    // cent, matching the API which computes the discount in integer cents.
+    // 15% of $34.90 is 523.5¢, so the discount is $5.24.
+    it('rounds a half-cent rate discount up to the nearest cent, matching the API', function (done) {
+      this.pricing
+        .plan('pct-tie-plan', { quantity: 1 })
+        .address({
+          country: 'US',
+          postal_code: 'NoTax'
+        })
+        .coupon('coop-pct-all')
+        .done(function (price) {
+          assert.equal(price.now.discount, '5.24');
+          done();
+        });
+    });
+
     it('should apply a single-use coupon correctly', function (done) {
       this.pricing
         .plan('basic', { quantity: 1 })


### PR DESCRIPTION
## Description

Percentage-coupon discounts were computed by multiplying **dollar floats** (e.g. `34.90 * 0.15 = 5.234999…`), which drifts just below the half-cent tie and rounds **down** — so Checkout and Recurly.js displayed a discount one cent smaller than the API/invoice actually charged. On a $34.90 plan with a 15%-off coupon, Checkout showed a **$5.23** discount ($29.67 total) while the invoice charged a **$5.24** discount ($29.66).

The API is correct: it multiplies **integer cents** (`3490 * 0.15 = 523.5`) and rounds to `524`. This PR adds a `roundRateDiscount(amount, rate)` helper that reduces the discountable amount to integer cents **before** applying the rate — matching the API — and routes both discount paths through it:

- `checkout/calculations.js#discountAmounts()` — what the hosted Checkout / `CheckoutPricing` renders
- `subscription/calculations.js#discount()` — `SubscriptionPricing`, used by Recurly.js forms

Notes for reviewers:
- A prior attempt (`ac86950`, shipped in **v4.40.0**) standardized the rounding helper but kept multiplying dollars, so it only fixed cases that didn't drift below the tie. This supersedes it.
- The same dollar-float × rate pattern still exists for **tax**, which recurly.js intentionally treats as an estimate (the authoritative figure comes from the tax service). Left as-is, out of scope.

## Testing

**Automated Test Coverage:**
- Run: `make test-unit`
- Result: **1173 examples, 0 failures** — includes new regression tests for both pricing paths (`test/unit/pricing/checkout/checkout.test.js`, `test/unit/pricing/subscription/subscription.test.js`)
- Lint: `make lint` — clean

**Manual verification:**
1. Configure a plan priced `34.90` and a percentage coupon at `15%` off.
2. Build a `CheckoutPricing` (or `SubscriptionPricing`) with that plan and coupon and reprice.
3. Expected: `price.now.discount === '5.24'` (previously `'5.23'`), matching the invoice/API.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>