### PR TITLE
fix: Round percentage coupon discounts to whole cents to match the API

### DIFF
--- a/lib/recurly/pricing/checkout/calculations.js
+++ b/lib/recurly/pricing/checkout/calculations.js
@@ -2,7 +2,7 @@ import each from 'component-each';
 import isEmpty from 'lodash.isempty';
 import Promise from 'promise';
 import uniq from 'array-unique';
-import { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
+import { clampToZero, decimalizeMember, round, roundRateDiscount } from '../../../util/decimalize';
 import groupBy from '../../../util/group-by';
 
 /**
@@ -336,10 +336,10 @@ export default class Calculations {
         // Amounts are left zero
       } else if (coupon.discount.rate) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon, { setupFees: false });
-        discountNow = round(discountableNow * coupon.discount.rate, 6);
+        discountNow = roundRateDiscount(discountableNow, coupon.discount.rate);
         // If coupon is single use and there is no free trial period on the plan, we want discountNext to be zero
         if (!coupon.single_use || discountableNow === 0) {
-          discountNext = round(discountableNext * coupon.discount.rate, 6);
+          discountNext = roundRateDiscount(discountableNext, coupon.discount.rate);
         }
       } else if (coupon.discount.amount) {
         const { discountableNow, discountableNext } = this.discountableSubtotals(coupon);

--- a/lib/recurly/pricing/subscription/calculations.js
+++ b/lib/recurly/pricing/subscription/calculations.js
@@ -1,7 +1,7 @@
 import each from 'component-each';
 import find from 'component-find';
 import isEmpty from 'lodash.isempty';
-import decimalize, { clampToZero, decimalizeMember, round } from '../../../util/decimalize';
+import decimalize, { clampToZero, decimalizeMember, round, roundRateDiscount } from '../../../util/decimalize';
 import { getTieredPricingTotal, getTieredPricingUnitAmount, isTieredAddOn } from './tiered-pricing-calculator';
 
 /**
@@ -248,8 +248,8 @@ export default class Calculations {
     if (!coupon) return;
 
     if (coupon.discount.rate) {
-      var discountNow = round(this.price.now.subtotal * coupon.discount.rate, 6);
-      var discountNext = round(this.price.next.subtotal * coupon.discount.rate, 6);
+      var discountNow = roundRateDiscount(this.price.now.subtotal, coupon.discount.rate);
+      var discountNext = roundRateDiscount(this.price.next.subtotal, coupon.discount.rate);
       this.price.now.discount = discountNow;
       this.price.next.discount = discountNext;
     } else if (coupon.discount.type === 'free_trial') {

--- a/lib/util/decimalize.js
+++ b/lib/util/decimalize.js
@@ -17,6 +17,12 @@ export function round (number, digits = 2) {
   return sign * Number(`${rounded}e-${digits}`);
 }
 
+// Applies a rate discount in integer cents, matching the billing API, so the
+// discount is a whole cent and the total it is subtracted from stays exact.
+export function roundRateDiscount (amount, rate) {
+  return round(round(amount * 100, 0) * rate / 100);
+}
+
 /**
  * Applies a decimal transform on an object's member
  *

--- a/test/unit/pricing/checkout/checkout.test.js
+++ b/test/unit/pricing/checkout/checkout.test.js
@@ -880,6 +880,8 @@ describe('CheckoutPricing', function () {
           .done(price => {
             assert.equal(price.now.discount, 5.24);
             assert.equal(price.now.adjustments, 34.90);
+            assert.equal(price.now.subtotal, 29.66);
+            assert.equal(price.now.total, 29.66);
             done();
           });
       });

--- a/test/unit/pricing/subscription/subscription.test.js
+++ b/test/unit/pricing/subscription/subscription.test.js
@@ -707,6 +707,8 @@ describe('Recurly.Pricing.Subscription', function () {
         .coupon('coop-pct-all')
         .done(function (price) {
           assert.equal(price.now.discount, '5.24');
+          assert.equal(price.now.subtotal, '29.66');
+          assert.equal(price.now.total, '29.66');
           done();
         });
     });


### PR DESCRIPTION
## Description

Percentage coupon discounts were derived from a dollar float and kept at 6-decimal precision. Because recurly.js **subtracts the discount to derive the total**, the un-rounded value threw the total (and the displayed subtotal) off by a cent:

On a **$34.90** plan with **15% off**, the cart showed a **$5.24** discount but a **$29.67** total and a **$34.91** subtotal, while the API/invoice charges **$29.66** (discount `$5.24`, subtotal `$34.90`).

Root cause: `34.90 * 0.15 = 5.234999…` as a dollar float. Rounding only the *displayed* discount to `5.24` hides the drift, but the total still subtracts the un-rounded `5.235` → `29.665` → `29.67`.

This computes the discount the way the billing API does — take the discountable amount to **integer cents**, apply the rate, and round to a **whole cent** — so the discount is a true cent value. The total and subtotal it produces then both reconcile with the invoice, on the **checkout** and **subscription** pricing paths.

| | discount | subtotal | total |
|---|---|---|---|
| before | $5.24 | $34.91 | $29.67 |
| after / API | $5.24 | $34.90 | $29.66 |

This supersedes the earlier `round(x, 6)` approach: that made the discount *display* correctly but left the total wrong.

## Testing

**Automated Test Coverage:**
- Run: `make test-unit`
- Result: **1276 examples, 0 failures**
- New assertions cover the full line — discount **and** subtotal **and** total — on both the checkout (`test/unit/pricing/checkout/checkout.test.js`) and subscription (`test/unit/pricing/subscription/subscription.test.js`) paths, so a discount that rounds correctly but throws the total off can't slip through.
- Lint: `make lint` — clean

**Manual verification:**
1. Plan priced `34.90`, percentage coupon `15%` off.
2. Build a `CheckoutPricing` (or `SubscriptionPricing`) with that plan and coupon and reprice.
3. Expected: `price.now.discount === '5.24'`, `price.now.subtotal === '29.66'`, `price.now.total === '29.66'` — matching the invoice.

