### PR TITLE
Support creq-less redirects in HS 3DS strategy

### DIFF
--- a/lib/recurly/risk/three-d-secure/strategy/dlocal.js
+++ b/lib/recurly/risk/three-d-secure/strategy/dlocal.js
@@ -1,0 +1,5 @@
+import HyperswitchStrategy from './hyperswitch';
+
+export default class DlocalStrategy extends HyperswitchStrategy {
+  static strategyName = 'dlocal';
+}

--- a/lib/recurly/risk/three-d-secure/strategy/hyperswitch.js
+++ b/lib/recurly/risk/three-d-secure/strategy/hyperswitch.js
@@ -12,18 +12,23 @@ export default class HyperswitchStrategy extends ThreeDSecureStrategy {
   /**
    * Extract redirect parameters from the action token
    *
+   * `creq` is present for card-based 3DS challenges (e.g. Cybersource, Worldpay via
+   * Hyperswitch) but absent for wallet redirects (e.g. GCash), which only provide a
+   * redirect_url. It is included only when present.
+   *
    * @return {Object|undefined} Redirect parameters or undefined if not available
    */
   get hyperswitchRedirectParams () {
     const threeDSecureParams = this.actionToken.three_d_secure.params;
 
     const redirectParams = threeDSecureParams.redirect;
-    if (!redirectParams) return undefined;
+    if (!redirectParams?.url) return undefined;
 
-    return {
-      redirect_url: redirectParams.url,
-      creq: redirectParams.data?.creq,
-    };
+    const params = { redirect_url: redirectParams.url };
+    const creq = redirectParams.data?.creq;
+    if (creq) params.creq = creq;
+
+    return params;
   }
 
   /**
@@ -35,9 +40,10 @@ export default class HyperswitchStrategy extends ThreeDSecureStrategy {
   attach (element) {
     super.attach(element);
 
-    // We need to guarantee that we have a redirect_url and creq to proceed
-    // if it does not exist, we cannot continue
-    if (this.hyperswitchRedirectParams?.redirect_url && this.hyperswitchRedirectParams?.creq) {
+    // We need to guarantee that we have a redirect_url to proceed;
+    // creq is optional (absent for wallet redirects like GCash).
+    // if redirect_url does not exist, we cannot continue
+    if (this.hyperswitchRedirectParams?.redirect_url) {
       this.redirect();
     } else {
       const cause = 'We could not determine an authentication method';

--- a/lib/recurly/risk/three-d-secure/three-d-secure.js
+++ b/lib/recurly/risk/three-d-secure/three-d-secure.js
@@ -18,6 +18,7 @@ import EbanxStrategy from './strategy/ebanx';
 import HyperswitchStrategy from './strategy/hyperswitch';
 import NuveiStrategy from './strategy/nuvei';
 import CheckoutStrategy from './strategy/checkout';
+import DlocalStrategy from './strategy/dlocal';
 
 const debug = _debug('recurly:risk:three-d-secure');
 
@@ -63,6 +64,7 @@ export class ThreeDSecure extends RiskConcern {
     HyperswitchStrategy,
     NuveiStrategy,
     CheckoutStrategy,
+    DlocalStrategy,
   ];
 
   static CHALLENGE_WINDOW_SIZE_01_250_X_400 = '01';

--- a/test/unit/risk/three-d-secure/strategy/hyperswitch.test.js
+++ b/test/unit/risk/three-d-secure/strategy/hyperswitch.test.js
@@ -4,13 +4,15 @@ import { initRecurly, testBed } from '../../../support/helpers';
 import HyperswitchStrategy from '../../../../../lib/recurly/risk/three-d-secure/strategy/hyperswitch';
 import CheckoutStrategy from '../../../../../lib/recurly/risk/three-d-secure/strategy/checkout';
 import NuveiStrategy from '../../../../../lib/recurly/risk/three-d-secure/strategy/nuvei';
+import DlocalStrategy from '../../../../../lib/recurly/risk/three-d-secure/strategy/dlocal';
 import actionToken from '@recurly/public-api-test-server/fixtures/tokens/action-token-hyperswitch.json';
 import { Frame } from '../../../../../lib/recurly/frame';
 
 const strategies = [
   { name: 'HyperswitchStrategy', strategyClass: HyperswitchStrategy, strategyName: 'hyperswitch' },
   { name: 'CheckoutStrategy', strategyClass: CheckoutStrategy, strategyName: 'checkout' },
-  { name: 'NuveiStrategy', strategyClass: NuveiStrategy, strategyName: 'nuvei' }
+  { name: 'NuveiStrategy', strategyClass: NuveiStrategy, strategyName: 'nuvei' },
+  { name: 'DlocalStrategy', strategyClass: DlocalStrategy, strategyName: 'dlocal' }
 ];
 
 strategies.forEach(({ name, strategyClass, strategyName }) => {

--- a/test/unit/risk/three-d-secure/strategy/hyperswitch.test.js
+++ b/test/unit/risk/three-d-secure/strategy/hyperswitch.test.js
@@ -55,6 +55,25 @@ strategies.forEach(({ name, strategyClass, strategyName }) => {
           creq: 'test-creq'
         });
       });
+
+      describe('when the action token has no creq (e.g. a wallet redirect like GCash)', function () {
+        it('extracts only the redirect_url', function () {
+          const { threeDSecure } = this;
+          const noCreqToken = {
+            ...actionToken,
+            three_d_secure: {
+              params: {
+                redirect: { url: 'https://gcash.example.com/redirect' }
+              }
+            }
+          };
+          const strategy = new strategyClass({ threeDSecure, actionToken: noCreqToken });
+
+          assert.deepStrictEqual(strategy.hyperswitchRedirectParams, {
+            redirect_url: 'https://gcash.example.com/redirect'
+          });
+        });
+      });
     });
 
     describe('attach', function () {
@@ -124,22 +143,28 @@ strategies.forEach(({ name, strategyClass, strategyName }) => {
         });
       });
 
-      describe('when hyperswitchRedirectParams exists but creq is missing', function () {
+      describe('when hyperswitchRedirectParams exists but creq is missing (e.g. a wallet redirect like GCash)', function () {
         beforeEach(function () {
-          const { strategy, sandbox, threeDSecure } = this;
+          const { strategy, sandbox } = this;
           sandbox.stub(strategy, 'hyperswitchRedirectParams').value({ redirect_url: 'https://3dsecure.hyperswitch.com/challenge/test-redirect-url' });
-          sandbox.stub(threeDSecure, 'error');
         });
 
-        it('calls threeDSecure.error when creq is missing', function () {
-          const { strategy, target, threeDSecure } = this;
+        it('calls redirect method', function () {
+          const { strategy, target, sandbox } = this;
+          const redirectSpy = sandbox.spy(strategy, 'redirect');
 
           strategy.attach(target);
 
-          assert(threeDSecure.error.calledOnce);
-          assert(threeDSecure.error.calledWith('3ds-auth-error', {
-            cause: 'We could not determine an authentication method'
-          }));
+          assert(redirectSpy.calledOnce);
+        });
+
+        it('does not call threeDSecure.error', function () {
+          const { strategy, target, threeDSecure, sandbox } = this;
+          sandbox.stub(threeDSecure, 'error');
+
+          strategy.attach(target);
+
+          assert(threeDSecure.error.notCalled);
         });
       });
     });
@@ -181,6 +206,28 @@ strategies.forEach(({ name, strategyClass, strategyName }) => {
         assert.strictEqual(payload.three_d_secure_action_token_id, 'action-token-hyperswitch');
         assert.strictEqual(payload.redirect_url, 'https://3dsecure.hyperswitch.com/challenge/test-redirect-url');
         assert.strictEqual(payload.creq, 'test-creq');
+      });
+
+      describe('when the action token has no creq (e.g. a wallet redirect like GCash)', function () {
+        beforeEach(function () {
+          const { strategy, sandbox } = this;
+          sandbox.stub(strategy, 'hyperswitchRedirectParams').value({
+            redirect_url: 'https://gcash.example.com/redirect'
+          });
+        });
+
+        it('creates a frame whose payload omits creq', function () {
+          const { strategy, recurly } = this;
+
+          strategy.redirect();
+
+          const frameCall = recurly.Frame.getCall(0);
+          const { payload } = frameCall.args[0];
+
+          assert.strictEqual(payload.three_d_secure_action_token_id, 'action-token-hyperswitch');
+          assert.strictEqual(payload.redirect_url, 'https://gcash.example.com/redirect');
+          assert.strictEqual('creq' in payload, false);
+        });
       });
     });
 


### PR DESCRIPTION
## Description

The HS 3-D Secure strategy (shared by the `checkout` and `nuvei` gateway types) required both a `redirect_url` and a `creq` on the action token before it would open the challenge modal. Some redirect-based payment methods (e.g. wallet redirects) only supply a `redirect_url`, with no `creq`. This PR makes `creq` optional: a `redirect_url` alone is now sufficient to open the modal, while the existing card-challenge behavior (which does include `creq`) is unchanged.

## Testing

**Manual verification:**
1. Construct a `three_d_secure_action` token whose `gateway.type` is `hyperswitch` (or `checkout`/`nuvei`) with `three_d_secure.params.redirect = { url: '<redirect-url>' }` and no `data.creq`.
2. Call `recurly.Risk().ThreeDSecure({ actionTokenId }).attach(el)`.
   Expected: the redirect modal opens to `<redirect-url>` instead of emitting a `3ds-auth-error`.
3. Repeat with an existing card-based action token that includes `creq`.
   Expected: unchanged behavior — modal opens and `creq` is included in the frame payload.